### PR TITLE
Closest point select

### DIFF
--- a/addons/rmsmartshape/assets/icon_editor_handle_selected.svg
+++ b/addons/rmsmartshape/assets/icon_editor_handle_selected.svg
@@ -1,0 +1,3 @@
+<svg  width="14" height="14" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+	<path d="m-3.035534-10.106602h6.071068v6.071068h-6.071068z" fill="#8ff" stroke="#000" stroke-linecap="square" transform="matrix(-.70710678 .70710678 -.70710678 -.70710678 0 0)"/>
+</svg>

--- a/addons/rmsmartshape/assets/icon_editor_handle_selected.svg.import
+++ b/addons/rmsmartshape/assets/icon_editor_handle_selected.svg.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/icon_editor_handle - Copy.svg-42b8a9842967012ee4be966c88f90acc.stex"
+path="res://.import/icon_editor_handle_selected.svg-356ef806610ee2a60b5838a989f58598.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://addons/rmsmartshape/assets/icon_editor_handle - Copy.svg"
-dest_files=[ "res://.import/icon_editor_handle - Copy.svg-42b8a9842967012ee4be966c88f90acc.stex" ]
+source_file="res://addons/rmsmartshape/assets/icon_editor_handle_selected.svg"
+dest_files=[ "res://.import/icon_editor_handle_selected.svg-356ef806610ee2a60b5838a989f58598.stex" ]
 
 [params]
 

--- a/addons/rmsmartshape/plugin-functionality.gd
+++ b/addons/rmsmartshape/plugin-functionality.gd
@@ -174,12 +174,12 @@ static func action_add_point(
 	update_method: String,
 	undo: UndoRedo,
 	s: SS2D_Shape_Base,
-	new_point: Vector2
+	new_point: Vector2,
+	idx: int = -1
 ) -> int:
 	"""
 	Will return key of added point
 	"""
-	var idx = -1
 	var new_key = s.get_next_key()
 	undo.create_action("Add Point: %s" % new_point)
 

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -1082,40 +1082,24 @@ func _input_handle_keyboard_event(event: InputEventKey) -> bool:
 				shape.set_as_dirty()
 				shape.update()
 				_gui_update_info_panels()
+
 		if kb.pressed and kb.scancode == KEY_ESCAPE:
 			# Hide edge_info_panel
 			if gui_edge_info_panel.visible:
 				gui_edge_info_panel.visible = false
 
-		if (
-			kb.scancode == KEY_SHIFT
-			or (
-				kb.scancode == KEY_ALT
-				and (current_mode == MODE.CREATE_VERT or current_mode == MODE.EDIT_VERT)
-			)
-		):
-			if Input.is_key_pressed(KEY_SHIFT) and not Input.is_key_pressed(KEY_ALT):
-				if not kb.echo:
-					current_action = select_verticies([closest_key], ACTION_VERT.NONE)
-			else:
-				deselect_verts()
-			update_overlays()
-
-		if kb.scancode == KEY_ALT or kb.scancode == KEY_SHIFT:
-			update_overlays()
-
-		if (
-			current_mode == MODE.CREATE_VERT
-			and (kb.scancode == KEY_ENTER or kb.scancode == KEY_ESCAPE)
-		):
-			_enter_mode(MODE.EDIT_VERT)
+			if current_mode == MODE.CREATE_VERT:
+				_enter_mode(MODE.EDIT_VERT)
 
 		if kb.scancode == KEY_CONTROL:
-			if kb.pressed:
+			if kb.pressed and not kb.echo:
 				on_edge = false
 				current_action = select_verticies([closest_key], ACTION_VERT.NONE)
 			else:
 				deselect_verts()
+			update_overlays()
+
+		if kb.scancode == KEY_ALT:
 			update_overlays()
 
 		return true

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -1056,8 +1056,8 @@ func _input_handle_keyboard_event(event: InputEventKey) -> bool:
 			if gui_edge_info_panel.visible:
 				gui_edge_info_panel.visible = false
 
-		if kb.scancode == KEY_CONTROL and current_mode == MODE.CREATE_VERT or current_mode == MODE.EDIT_VERT:
-			if kb.pressed:
+		if kb.scancode == KEY_CONTROL or kb.scancode == KEY_ALT and (current_mode == MODE.CREATE_VERT or current_mode == MODE.EDIT_VERT):
+			if Input.is_key_pressed(KEY_CONTROL) and not Input.is_key_pressed(KEY_ALT):
 				if not kb.echo:
 					current_action = select_verticies([closest_key], ACTION_VERT.NONE)
 			else:
@@ -1328,7 +1328,7 @@ func _input_handle_mouse_motion_event(
 		var mouse_over_key = get_mouse_over_vert_key(event, grab_threshold)
 		var mouse_over_width_handle = get_mouse_over_width_handle(event, grab_threshold)
 
-		if Input.is_key_pressed(KEY_CONTROL) and mouse_over_width_handle == -1 and mouse_over_key == -1:
+		if Input.is_key_pressed(KEY_CONTROL) and not Input.is_key_pressed(KEY_ALT) and mouse_over_width_handle == -1 and mouse_over_key == -1:
 			mouse_over_key = closest_key
 
 		on_width_handle = false


### PR DESCRIPTION
- holding down CTRL highlights the closest point to your mouse, you can then start dragging it, remove it or change it's curve just as if your mouse was on the point. Makes editing a shape way less tedious, quicker and more fun
- holding down ALT makes a new point between the closest edge rather than the end of the shape. The old behavior is still present in the add point tool, which makes sense because that create point tool is really for drawing the initial shape and the edit tool is for editing that shape without having to care of where you started/finished drawing it.
- minor change: made the second preview line when using create vertex tool thinner, this helps to know between where the next point will be created. Also makes it more obvious that you shouldn't draw shapes CCW because you see clearer what's going wrong
