### PR TITLE
Change Anchor.svg color to blue

### DIFF
--- a/addons/rmsmartshape/assets/Anchor.svg
+++ b/addons/rmsmartshape/assets/Anchor.svg
@@ -1,1 +1,12 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m8 1a3 3 0 0 0 -3 3 3 3 0 0 0 2 2.8262v.17383h-2v2h2v3.8984a5 5 0 0 1 -3.8281-3.6035l-1.9336.51758a7 7 0 0 0 6.7617 5.1875 7 7 0 0 0 6.7617-5.1875l-1.9375-.51953a5 5 0 0 1 -3.8242 3.6035v-3.8965h2v-2h-2v-.17578a3 3 0 0 0 2-2.8242 3 3 0 0 0 -3-3zm0 2a1 1 0 0 1 1 1 1 1 0 0 1 -1 1 1 1 0 0 1 -1-1 1 1 0 0 1 1-1z" fill="#a5efac"/></svg>
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path d="m8 1a3 3 0 0 0-3 3 3 3 0 0 0 2 2.8262v0.17383h-2v2h2v3.8984a5 5 0 0 1-3.8281-3.6035l-1.9336 0.51758a7 7 0 0 0 6.7617 5.1875 7 7 0 0 0 6.7617-5.1875l-1.9375-0.51953a5 5 0 0 1-3.8242 3.6035v-3.8965h2v-2h-2v-0.17578a3 3 0 0 0 2-2.8242 3 3 0 0 0-3-3zm0 2a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1z" fill="#a5b7f3" fill-opacity=".98824"/>
+</svg>


### PR DESCRIPTION
Change the Anchor.svg color to blue, because new users might think that it's a Control node when it's green.

From:
![Screenshot 2021-02-17 110148](https://user-images.githubusercontent.com/47501982/108188285-b29cca00-710f-11eb-844e-187dce4f5a94.png)
To:
![Screenshot 2021-02-17 110214](https://user-images.githubusercontent.com/47501982/108188290-b4668d80-710f-11eb-8144-b5e65221f9e7.png)

This is my first ever pull request, let me know if I did anything wrong.