### PR TITLE
randomize texture choice in edge material

### DIFF
--- a/addons/rmsmartshape/materials/edge_material.gd
+++ b/addons/rmsmartshape/materials/edge_material.gd
@@ -29,6 +29,8 @@ export (Array, Texture) var textures_taper_right: Array = [] setget _set_texture
 export (Array, Texture) var texture_normals_taper_left: Array = [] setget _set_texture_normals_taper_left
 export (Array, Texture) var texture_normals_taper_right: Array = [] setget _set_texture_normals_taper_right
 
+# If the texture choice should be randomized instead of the choice by point setup
+export (bool) var randomize_texture: bool = false setget _set_randomize_texture
 # If corner textures should be used
 export (bool) var use_corner_texture: bool = true setget _set_use_corner
 # If taper textures should be used
@@ -90,6 +92,11 @@ func _set_textures_taper_right(a: Array):
 
 func _set_texture_normals_taper_right(a: Array):
 	texture_normals_taper_right = a
+	emit_signal("changed")
+
+
+func _set_randomize_texture(b: bool):
+	randomize_texture = b
 	emit_signal("changed")
 
 

--- a/addons/rmsmartshape/shapes/shape_base.gd
+++ b/addons/rmsmartshape/shapes/shape_base.gd
@@ -1675,7 +1675,11 @@ func _build_edge_with_material(edge_data: EdgeMaterialData, c_offset: float, wra
 		var pt_next = t_points[tess_idx_next]
 		var pt_prev = t_points[tess_idx_prev]
 
-		var texture_idx = get_point_texture_index(vert_key)
+		var texture_idx = 0
+		if edge_material.randomize_texture:
+			texture_idx = randi() % edge_material.textures.size()
+		else :
+			get_point_texture_index(vert_key)
 		var flip_x = get_point_texture_flip(vert_key)
 
 		var width = _get_width_for_tessellated_point(points, t_points, tess_idx)


### PR DESCRIPTION
Hi,

This small edit adds a checkbox "randomize_texture" in the Edge Material.
If this bool is true, instead of choosing the texture from the point property, SS2D will randomize the choice of texture inside the textures array.

atn