### PR TITLE
bug correction on vertex index

### DIFF
--- a/addons/rmsmartshape/shapes/shape_base.gd
+++ b/addons/rmsmartshape/shapes/shape_base.gd
@@ -1679,7 +1679,7 @@ func _build_edge_with_material(edge_data: EdgeMaterialData, c_offset: float, wra
 		if edge_material.randomize_texture:
 			texture_idx = randi() % edge_material.textures.size()
 		else :
-			get_point_texture_index(vert_key)
+			texture_idx = get_point_texture_index(vert_key)
 		var flip_x = get_point_texture_flip(vert_key)
 
 		var width = _get_width_for_tessellated_point(points, t_points, tess_idx)


### PR DESCRIPTION
Hi, the last pull introduced a bug (can no more choose the idx texture for a vertex) that is corrected in this PR.
I am a bit ashamed to have forgotten this var association:
"texture_idx = "
It should work a bit better now ... 
sorry about that,
atn