### PR TITLE
Fixes #87: Uses corner texture for wrap around corners on closed shapes

### DIFF
--- a/addons/rmsmartshape/shapes/shape_closed.gd
+++ b/addons/rmsmartshape/shapes/shape_closed.gd
@@ -343,6 +343,14 @@ func import_from_legacy(legacy: RMSmartShape2D):
 		set_point_width(key, legacy.get_point_width(i))
 
 
+"""
+Differs from the main get_meta_material_index_mapping
+in that the points wrap around
+"""
+static func get_meta_material_index_mapping(s_material: SS2D_Material_Shape, verts: Array) -> Array:
+	return _get_meta_material_index_mapping(s_material, verts, true)
+
+
 func _merge_index_maps(imaps:Array, verts:Array) -> Array:
 	# See if any edges have both the first (0) and last idx (size)
 	# Merge them into one if so

--- a/gut/unit/test_edge.gd
+++ b/gut/unit/test_edge.gd
@@ -30,7 +30,7 @@ func test_generate_mesh_from_quad_sequence():
 	var quad_arrays = SS2D_Edge.get_consecutive_quads_for_mesh(quads)
 
 	for quad_array in quad_arrays:
-		var am = SS2D_Edge.generate_array_mesh_from_quad_sequence(quad_array, false)
+		var am = SS2D_Edge.generate_array_mesh_from_quad_sequence(quad_array, false, 0)
 		assert_eq(am.get_surface_count(), 1)
 		var arrays = am.surface_get_arrays(0)
 		var verts = arrays[Mesh.ARRAY_VERTEX]


### PR DESCRIPTION
This pull request fixes issue #87. Closed shapes will correctly use corner textures on first/last vertex. Open shapes are unaffected by this change.

I have verified that all the unit and integration tests are still working (I had to fix an unrelated error in one of the unit tests).

Compare with screenshot in #87.
<img width="1457" alt="Screen Shot 2021-09-18 at 3 03 41 AM" src="https://user-images.githubusercontent.com/2592431/133879923-063699b0-8980-49ea-ac3e-b9e3520516f2.png">
