### PR TITLE
Fixes #91: Instead of adding extra edge to fix corner wrap around, add the corner quad directly

### DIFF
--- a/addons/rmsmartshape/shapes/shape_base.gd
+++ b/addons/rmsmartshape/shapes/shape_base.gd
@@ -1149,8 +1149,7 @@ static func get_meta_material_index_mapping(s_material: SS2D_Material_Shape, ver
 static func _get_meta_material_index_mapping(s_material: SS2D_Material_Shape, verts: Array, wrap_around: bool) -> Array:
 	var final_edges: Array = []
 	var edge_building: Dictionary = {}
-	var vert_count = verts.size() if wrap_around else verts.size() - 1
-	for idx in range(0, vert_count, 1):
+	for idx in range(0, verts.size() - 1, 1):
 		var idx_next = _get_next_point_index(idx, verts, wrap_around)
 		var pt = verts[idx]
 		var pt_next = verts[idx_next]
@@ -1679,6 +1678,23 @@ func _build_edge_with_material(index_map: SS2D_IndexMap,  c_offset: float, defau
 				else:
 					new_quad.texture = taper_texture
 					new_quad.texture_normal = taper_texture_normal
+
+		# Final point for closed shapes fix
+		# Corner quads aren't always correctly when the corner is between final and first pt
+		if is_last_point and is_edge_contiguous:
+			var idx_mid = verts_t.size() - 1
+			var idx_next = _get_next_unique_point_idx(idx_mid, verts_t, true)
+			var idx_prev = _get_previous_unique_point_idx(idx_mid, verts_t, true)
+			var p_p = verts_t[idx_prev]
+			var p_m = verts_t[idx_mid]
+			var p_n = verts_t[idx_next]
+			var w_p = _get_width_for_tessellated_point(verts, verts_t, idx_prev)
+			var w_m = _get_width_for_tessellated_point(verts, verts_t, idx_mid)
+			var q = _edge_generate_corner(
+				p_p, p_m, p_n, w_p, w_m, tex_size.y, edge_material, texture_idx, c_scale, c_offset
+			)
+			if q != null:
+				new_quads.push_back(q)
 
 		# Add new quads to edge
 		for q in new_quads:


### PR DESCRIPTION
Fixes #91 by reverting part of the changes from #88 (which was my fix for #87). My original fix in #88 forced a new corner quad to be generated for wrap-around corners by adding an extra edge material index map. While this did generate the corner quad, it was incorrect because it also generated an extraneous edge quad for the edge following the corner.

I found some code [here](https://github.com/SirRamEsq/SmartShape2D/commit/d33904b578dfdbcd2a70606ab107b25e0e46d44d#diff-4a7d9133fa4de4ba21883e56fe672824c0841858d35ec86841f8b3f01ad10349L1661) that generates a corner quad for wrap-around corners. This code seems to fix #87 without regressing #91 (see screenshot below).

It seems to work, but I have no idea if this is actually correct. As you can see from [this commit](https://github.com/SirRamEsq/SmartShape2D/commit/d33904b578dfdbcd2a70606ab107b25e0e46d44d#diff-4a7d9133fa4de4ba21883e56fe672824c0841858d35ec86841f8b3f01ad10349L1661), it was commented out and ultimately removed.

<img width="1270" alt="Screen Shot 2021-10-25 at 3 51 38 AM" src="https://user-images.githubusercontent.com/2592431/138656102-86464b48-3345-4b2b-b4b2-e867b7122fe9.png">
