### PR TITLE
Add "Show behind parent" option for fill textures

### DIFF
--- a/addons/rmsmartshape/materials/shape_material.gd
+++ b/addons/rmsmartshape/materials/shape_material.gd
@@ -13,6 +13,7 @@ export (Array, Resource) var _edge_meta_materials: Array = [] setget set_edge_me
 export (Array, Texture) var fill_textures: Array = [] setget set_fill_textures
 export (Array, Texture) var fill_texture_normals: Array = [] setget set_fill_texture_normals
 export (int) var fill_texture_z_index: int = -10 setget set_fill_texture_z_index
+export (int) var fill_texture_show_behind_parent: bool = false setget set_fill_texture_show_behind_parent
 export (float) var fill_mesh_offset: float = 0.0 setget set_fill_mesh_offset
 export (Material) var fill_mesh_material: Material = null setget set_fill_mesh_material
 
@@ -80,6 +81,11 @@ func set_fill_texture_normals(a: Array):
 
 func set_fill_texture_z_index(i: int):
 	fill_texture_z_index = i
+	emit_signal("changed")
+
+
+func set_fill_texture_show_behind_parent(value: bool):
+	fill_texture_show_behind_parent = value
 	emit_signal("changed")
 
 

--- a/addons/rmsmartshape/shapes/mesh.gd
+++ b/addons/rmsmartshape/shapes/mesh.gd
@@ -15,6 +15,7 @@ var mesh_transform: Transform2D = Transform2D()
 var material: Material = null
 var z_index: int = 0
 var z_as_relative: bool = true
+var show_behind_parent: bool = false
 
 
 func _init(
@@ -42,6 +43,7 @@ func duplicate(sub_resource: bool = false):
 	_new.material = material
 	_new.z_index = z_index
 	_new.z_as_relative = z_as_relative
+	_new.show_behind_parent = show_behind_parent
 	_new.meshes = []
 	if sub_resource:
 		for m in meshes:

--- a/addons/rmsmartshape/shapes/shape_closed.gd
+++ b/addons/rmsmartshape/shapes/shape_closed.gd
@@ -197,6 +197,7 @@ func _build_fill_mesh(points: Array, s_mat: SS2D_Material_Shape) -> Array:
 	mesh_data.material = s_mat.fill_mesh_material
 	mesh_data.z_index = s_mat.fill_texture_z_index
 	mesh_data.z_as_relative = true
+	mesh_data.show_behind_parent = s_mat.fill_texture_show_behind_parent
 	meshes.push_back(mesh_data)
 
 	return meshes

--- a/addons/rmsmartshape/shapes/shape_render.gd
+++ b/addons/rmsmartshape/shapes/shape_render.gd
@@ -15,10 +15,12 @@ func set_mesh(m):
 		material = mesh.material
 		z_index = mesh.z_index
 		z_as_relative = mesh.z_as_relative
+		show_behind_parent = mesh.show_behind_parent
 	else:
 		material = null
 		z_index = 0
 		z_as_relative = true
+		show_behind_parent = false
 	update()
 
 


### PR DESCRIPTION
Exposes the "show behind parent" property for fill textures.
This is useful when having multiple smart shapes that overlap each other.
The following screenshot shows what usually happens:  the edges of the underlying shape overlap the fill mesh of the shape above.
![screenshot20220616003851](https://user-images.githubusercontent.com/7116001/173955658-10d2ea47-ae45-469e-8f84-d1359f31a7d6.png)

With this patch, you can set the following properties in the shape material to get a better overlapping behavior that always works without fiddling with z-indexes.
```
Fill Texture Show Behind Parent = true
Fill Texture Z Index = 0
``` 
![screenshot20220616003941](https://user-images.githubusercontent.com/7116001/173955661-ab56280a-45d5-4700-b4bf-ffc9566f4e78.png)
