### PR TITLE
Fix anchors resetting shape path on _exit_tree

### DIFF
--- a/addons/rmsmartshape/shapes/shape_anchor.gd
+++ b/addons/rmsmartshape/shapes/shape_anchor.gd
@@ -109,7 +109,7 @@ func _process(delta):
 
 
 func _monitored_node_leaving():
-	set_shape_path("")
+	pass
 
 
 func _handle_point_change():


### PR DESCRIPTION
Currently, anchors explicitly reset the target nodepath when _exit_tree is triggered. 
This would occur for example when switching scene tabs and is very annoying to work with.
This patch removes this behavior.