### PR TITLE
Slightly offset vertex info panel to be less obstructive

### DIFF
--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -101,6 +101,8 @@ var gui_point_info_panel = GUI_POINT_INFO_PANEL.instance()
 var gui_edge_info_panel = GUI_EDGE_INFO_PANEL.instance()
 var gui_snap_settings = GUI_SNAP_POPUP.instance()
 
+const GUI_POINT_INFO_PANEL_OFFSET = Vector2(256, 130)
+
 # This is the shape node being edited
 var shape = null
 # For when a legacy shape is selected
@@ -1473,7 +1475,7 @@ func _input_handle_mouse_motion_event(
 	var t: Transform2D = et * shape.get_global_transform()
 	var mm: InputEventMouseMotion = event
 	var delta_current_pos = et.affine_inverse().xform(mm.position)
-	gui_point_info_panel.rect_position = mm.position + Vector2(256, -24)
+	gui_point_info_panel.rect_position = mm.position + GUI_POINT_INFO_PANEL_OFFSET
 	var delta = delta_current_pos - _mouse_motion_delta_starting_pos
 
 	closest_key = get_closest_vert_to_point(shape, delta_current_pos)


### PR DESCRIPTION
When hovering over a vertex in vertex-edit-mode, a popup is shown to display information about this vertex.
I always found this popup very obstructive as it hides exactly that part of the screen I'm currently editing.
This patch offsets the info panel slightly downwards, so it still feels connected to the vertex, but does not occlude the edited area.

Before:
![screenshot20220616000430](https://user-images.githubusercontent.com/7116001/173957430-2aeab58e-2e95-455f-a7d1-1fce96047c28.png)

After:
![screenshot20220616003742](https://user-images.githubusercontent.com/7116001/173957431-4895c133-4dba-4bc9-94b8-bdeca0f0d25c.png)
