### PR TITLE
Improve UX and performance with deferred updates and small optimisations

### DIFF
--- a/addons/rmsmartshape/actions/action_add_point.gd
+++ b/addons/rmsmartshape/actions/action_add_point.gd
@@ -8,15 +8,17 @@ var _close_shape: ActionCloseShape
 const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
 var _invert_orientation: ActionInvertOrientation
 
+var _commit_update: bool
 var _shape: SS2D_Shape_Base
 var _key: int
 var _position: Vector2
 var _idx: int
 
 
-func _init(shape: SS2D_Shape_Base, position: Vector2, idx: int = -1) -> void:
+func _init(shape: SS2D_Shape_Base, position: Vector2, idx: int = -1, commit_update: bool = true) -> void:
 	_shape = shape
 	_position = position
+	_commit_update = commit_update
 	_idx = _shape.adjust_add_point_index(idx)
 	_key = _shape.reserve_key()
 	_invert_orientation = ActionInvertOrientation.new(shape)
@@ -32,7 +34,8 @@ func do() -> void:
 	_key = _shape.add_point(_position, _idx, _key)
 	_close_shape.do()
 	_invert_orientation.do()
-	_shape.end_update()
+	if _commit_update:
+		_shape.end_update()
 
 
 func undo() -> void:

--- a/addons/rmsmartshape/actions/action_delete_point.gd
+++ b/addons/rmsmartshape/actions/action_delete_point.gd
@@ -18,10 +18,12 @@ var _points_in: PackedVector2Array
 var _points_out: PackedVector2Array
 var _properties: Array[SS2D_VertexProperties]
 var _constraints: Dictionary
+var _commit_update: bool
 
 
-func _init(shape: SS2D_Shape_Base, key: int) -> void:
+func _init(shape: SS2D_Shape_Base, key: int, commit_update: bool = true) -> void:
 	_shape = shape
+	_commit_update = commit_update
 	_invert_orientation = ActionInvertOrientation.new(shape)
 	_close_shape = ActionCloseShape.new(shape)
 
@@ -48,7 +50,8 @@ func do() -> void:
 		_shape.remove_point(k)
 	_close_shape.do()
 	_invert_orientation.do()
-	_shape.end_update()
+	if _commit_update:
+		_shape.end_update()
 
 
 func undo() -> void:

--- a/addons/rmsmartshape/actions/action_split_curve.gd
+++ b/addons/rmsmartshape/actions/action_split_curve.gd
@@ -2,8 +2,8 @@ extends "res://addons/rmsmartshape/actions/action_add_point.gd"
 
 ## ActionSplitCurve
 
-func _init(shape: SS2D_Shape_Base, idx: int, gpoint: Vector2, xform: Transform2D) -> void:
-	super._init(shape, xform.affine_inverse() * gpoint, idx)
+func _init(shape: SS2D_Shape_Base, idx: int, gpoint: Vector2, xform: Transform2D, commit_update: bool = true) -> void:
+	super._init(shape, xform.affine_inverse() * gpoint, idx, commit_update)
 
 
 func get_name() -> String:

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -707,8 +707,6 @@ func _forward_canvas_draw_over_viewport(overlay: Control):
 			draw_freehand_circle(overlay)
 			draw_mode_edit_vert(overlay, false)
 
-	shape.queue_redraw()
-
 
 func draw_freehand_circle(overlay: Control) -> void:
 	var mouse: Vector2 = overlay.get_local_mouse_position()
@@ -1085,7 +1083,6 @@ func _input_handle_mouse_wheel(btn: int) -> bool:
 			var tex_idx: int = shape.get_point_texture_index(key) + texture_idx_step
 			shape.set_point_texture_index(key, tex_idx)
 
-		shape.set_as_dirty()
 		update_overlays()
 		_gui_update_info_panels()
 		return true
@@ -1102,8 +1099,6 @@ func _input_handle_keyboard_event(event: InputEventKey) -> bool:
 			if kb.pressed and kb.keycode == KEY_SPACE:
 				var key: int = current_action.current_point_key()
 				shape.set_point_texture_flip(key, not shape.get_point_texture_flip(key))
-				shape.set_as_dirty()
-				shape.queue_redraw()
 				_gui_update_info_panels()
 
 		if kb.pressed and kb.keycode == KEY_ESCAPE:
@@ -1344,7 +1339,6 @@ func _input_motion_move_control_points(delta: Vector2, _in: bool, _out: bool) ->
 		if _out:
 			shape.set_point_out(key, new_position_out)
 			rslt = true
-		shape.set_as_dirty()
 		update_overlays()
 
 	return rslt

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -284,6 +284,23 @@ func _gui_update_vert_info_panel() -> void:
 	gui_point_info_panel.set_flip(properties.flip)
 
 
+func _load_config() -> void:
+	var conf := ConfigFile.new()
+	conf.load(get_editor_interface().get_editor_paths().get_project_settings_dir().path_join("ss2d.cfg"))
+	_defer_mesh_updates = conf.get_value("options", "defer_mesh_updates", false)
+	tb_options_popup.set_item_checked(OPTIONS_MENU.ID_DEFER_MESH_UPDATES, _defer_mesh_updates)
+	tb_snap_popup.set_item_checked(SNAP_MENU.ID_USE_GRID_SNAP, conf.get_value("options", "use_grid_snap", false))
+	tb_snap_popup.set_item_checked(SNAP_MENU.ID_SNAP_RELATIVE, conf.get_value("options", "snap_relative", false))
+
+
+func _save_config() -> void:
+	var conf := ConfigFile.new()
+	conf.set_value("options", "defer_mesh_updates", _defer_mesh_updates)
+	conf.set_value("options", "use_grid_snap", tb_snap_popup.is_item_checked(SNAP_MENU.ID_USE_GRID_SNAP))
+	conf.set_value("options", "snap_relative", tb_snap_popup.is_item_checked(SNAP_MENU.ID_SNAP_RELATIVE))
+	conf.save(get_editor_interface().get_editor_paths().get_project_settings_dir().path_join("ss2d.cfg"))
+
+
 func _process(_delta: float) -> void:
 	if current_mode == MODE.FREEHAND:
 		current_zoom_level = get_canvas_scale()
@@ -370,6 +387,7 @@ func _init() -> void:
 func _ready() -> void:
 	# Support the undo-redo actions
 	_gui_build_toolbar()
+	_load_config()
 	add_child(gui_point_info_panel)
 	gui_point_info_panel.visible = false
 	add_child(gui_edge_info_panel)
@@ -406,6 +424,8 @@ func _enter_tree() -> void:
 func _exit_tree() -> void:
 	if (plugin != null):
 		remove_inspector_plugin(plugin)
+
+	_save_config()
 
 	gui_point_info_panel.visible = false
 	gui_edge_info_panel.visible = false

--- a/addons/rmsmartshape/shapes/shape_base.gd
+++ b/addons/rmsmartshape/shapes/shape_base.gd
@@ -232,7 +232,7 @@ func set_render_node_owners(v: bool) -> void:
 
 
 func update_render_nodes() -> void:
-	set_render_node_owners(editor_debug)
+#	set_render_node_owners(editor_debug)
 	set_render_node_light_masks(light_mask)
 
 

--- a/addons/rmsmartshape/shapes/shape_base.gd
+++ b/addons/rmsmartshape/shapes/shape_base.gd
@@ -20,7 +20,7 @@ const TUP = preload("../lib/tuple.gd")
 #-DECLARATIONS-#
 ################
 
-var _dirty: bool = true
+var _dirty: bool = false
 var _edges: Array[SS2D_Edge] = []
 var _meshes: Array[SS2D_Mesh] = []
 var _is_instantiable: bool = false
@@ -31,7 +31,6 @@ var _curve_no_control_points: Curve2D = Curve2D.new()
 var can_edit: bool = true
 
 signal points_modified
-signal on_dirty_update
 signal make_unique_pressed(shape: SS2D_Shape_Base)
 
 enum ORIENTATION { COLINEAR, CLOCKWISE, C_CLOCKWISE }
@@ -676,10 +675,6 @@ func _draw_debug(edges: Array[SS2D_Edge]) -> void:
 			q.render_points(1, 1.0, self)
 
 
-func _process(_delta: float) -> void:
-	_on_dirty_update()
-
-
 func _exit_tree() -> void:
 	if shape_material != null:
 		if shape_material.is_connected("changed", self._handle_material_change):
@@ -1141,6 +1136,8 @@ func _handle_material_override_change(_tuple) -> void:
 
 
 func set_as_dirty() -> void:
+	if not _dirty:
+		call_deferred("_on_dirty_update")
 	_dirty = true
 
 
@@ -1181,7 +1178,6 @@ func _on_dirty_update() -> void:
 			cache_meshes()
 		queue_redraw()
 		_dirty = false
-		emit_signal("on_dirty_update")
 
 
 # TODO, Migrate these 'point index' functions to a helper library and make static?

--- a/addons/rmsmartshape/shapes/shape_base.gd
+++ b/addons/rmsmartshape/shapes/shape_base.gd
@@ -544,8 +544,9 @@ func get_point_texture_index(key: int) -> int:
 
 func set_point_texture_flip(key: int, flip: bool) -> void:
 	var props: SS2D_VertexProperties = _points.get_point_properties(key)
-	props.flip = flip
-	_points.set_point_properties(key, props)
+	if props.flip != flip:
+		props.flip = flip
+		_points.set_point_properties(key, props)
 
 
 func get_point_texture_flip(key: int) -> bool:

--- a/addons/rmsmartshape/strings.gd
+++ b/addons/rmsmartshape/strings.gd
@@ -10,3 +10,6 @@ const EN_TOOLTIP_PIVOT := "Sets the origin of the shape"
 const EN_TOOLTIP_COLLISION := "Add static body parent and collision polygon sibling\nUse this to auto generate collision Nodes"
 const EN_TOOLTIP_SNAP := "Snapping Options"
 const EN_TOOLTIP_IMPORT := "Convert old Smartshape to new Smartshape"
+const EN_TOOLTIP_MORE_OPTIONS := "More Options"
+
+const EN_OPTIONS_DEFER_MESH_UPDATES := "Defer Mesh Updates"


### PR DESCRIPTION
This PR implements deferred mesh updates to improve performance and UX with big shapes:

![Deferred Mesh Generation](https://user-images.githubusercontent.com/2766569/234982831-745f6a17-5742-4d31-806d-03b143f96fa0.gif)

Deferred updates are turned off by default and can be turned on in the toolbar:

![image](https://user-images.githubusercontent.com/2766569/234983419-e2e92fd8-4e4c-4719-8bde-652a8b279189.png)

Setting of deferred updates is persisted in a config file along with snapping settings.

Additionally:
1. Removes unneeded "_process" calls, excessive draws and shape mesh updates.
2. Turns off setting render node owners. It seems to slow down editor as things stand with Godot 4.0. The purpose of that function still remains unclear and things seem to work fine without it.

All the tests pass.

#### Testing

While under review, my PRs (#118, #123 and #126) are available merged in this branch: https://github.com/limbonaut/SmartShape2D/tree/integration
