### PR TITLE
Improve UX when creating open and closed shapes

### DIFF
--- a/addons/rmsmartshape/actions/action_add_collision_nodes.gd
+++ b/addons/rmsmartshape/actions/action_add_collision_nodes.gd
@@ -2,13 +2,13 @@ extends SS2D_Action
 
 ## ActionAddCollisionNodes
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 
 var _saved_index: int
 var _saved_pos: Vector2
 
 
-func _init(shape: SS2D_Shape_Base) -> void:
+func _init(shape: SS2D_Shape) -> void:
 	_shape = shape
 
 

--- a/addons/rmsmartshape/actions/action_add_point.gd
+++ b/addons/rmsmartshape/actions/action_add_point.gd
@@ -6,13 +6,13 @@ const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/acti
 var _invert_orientation: ActionInvertOrientation
 
 var _commit_update: bool
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _key: int
 var _position: Vector2
 var _idx: int
 
 
-func _init(shape: SS2D_Shape_Base, position: Vector2, idx: int = -1, commit_update: bool = true) -> void:
+func _init(shape: SS2D_Shape, position: Vector2, idx: int = -1, commit_update: bool = true) -> void:
 	_shape = shape
 	_position = position
 	_commit_update = commit_update

--- a/addons/rmsmartshape/actions/action_add_point.gd
+++ b/addons/rmsmartshape/actions/action_add_point.gd
@@ -2,9 +2,6 @@ extends SS2D_Action
 
 ## ActionAddPoint
 
-const ActionCloseShape := preload("res://addons/rmsmartshape/actions/action_close_shape.gd")
-var _close_shape: ActionCloseShape
-
 const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
 var _invert_orientation: ActionInvertOrientation
 
@@ -22,7 +19,6 @@ func _init(shape: SS2D_Shape_Base, position: Vector2, idx: int = -1, commit_upda
 	_idx = _shape.adjust_add_point_index(idx)
 	_key = _shape.reserve_key()
 	_invert_orientation = ActionInvertOrientation.new(shape)
-	_close_shape = ActionCloseShape.new(shape)
 
 
 func get_name() -> String:
@@ -32,7 +28,6 @@ func get_name() -> String:
 func do() -> void:
 	_shape.begin_update()
 	_key = _shape.add_point(_position, _idx, _key)
-	_close_shape.do()
 	_invert_orientation.do()
 	if _commit_update:
 		_shape.end_update()
@@ -41,7 +36,6 @@ func do() -> void:
 func undo() -> void:
 	_shape.begin_update()
 	_invert_orientation.undo()
-	_close_shape.undo()
 	_shape.remove_point(_key)
 	_shape.end_update()
 

--- a/addons/rmsmartshape/actions/action_close_shape.gd
+++ b/addons/rmsmartshape/actions/action_close_shape.gd
@@ -2,6 +2,9 @@ extends SS2D_Action
 
 ## ActionCloseShape
 
+const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
+var _invert_orientation: ActionInvertOrientation
+
 var _shape: SS2D_Shape_Base
 var _key: int
 var _performed: bool
@@ -9,6 +12,7 @@ var _performed: bool
 
 func _init(shape: SS2D_Shape_Base) -> void:
 	_shape = shape
+	_invert_orientation = ActionInvertOrientation.new(shape)
 
 
 func get_name() -> String:
@@ -18,10 +22,16 @@ func get_name() -> String:
 func do() -> void:
 	_performed = _shape.can_close()
 	if _performed:
+		_shape.begin_update()
 		_key = _shape.close_shape(_key)
+		_invert_orientation.do()
+		_shape.end_update()
 
 
 func undo() -> void:
 	if _performed:
+		_shape.begin_update()
+		_invert_orientation.undo()
 		_shape.remove_point(_key)
+		_shape.end_update()
 

--- a/addons/rmsmartshape/actions/action_close_shape.gd
+++ b/addons/rmsmartshape/actions/action_close_shape.gd
@@ -5,12 +5,12 @@ extends SS2D_Action
 const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
 var _invert_orientation: ActionInvertOrientation
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _key: int
 var _performed: bool
 
 
-func _init(shape: SS2D_Shape_Base) -> void:
+func _init(shape: SS2D_Shape) -> void:
 	_shape = shape
 	_invert_orientation = ActionInvertOrientation.new(shape)
 

--- a/addons/rmsmartshape/actions/action_close_shape.gd
+++ b/addons/rmsmartshape/actions/action_close_shape.gd
@@ -35,3 +35,6 @@ func undo() -> void:
 		_shape.remove_point(_key)
 		_shape.end_update()
 
+
+func get_key() -> int:
+	return _key

--- a/addons/rmsmartshape/actions/action_cut_edge.gd
+++ b/addons/rmsmartshape/actions/action_cut_edge.gd
@@ -1,0 +1,31 @@
+extends SS2D_Action
+
+## ActionCutEdge
+
+var _shape: SS2D_Shape_Base
+var _idx: int
+var _closing_key: int
+
+
+func _init(shape: SS2D_Shape_Base, key: int) -> void:
+	_shape = shape
+	_idx = shape.get_point_index(key)
+
+
+func get_name() -> String:
+	return "Cut Edge"
+
+
+func do() -> void:
+	_shape.begin_update()
+	var last_idx: int = _shape.get_point_count() - 1
+	_closing_key = _shape.get_point_key_at_index(last_idx)
+	_shape.cut_edge(_idx)
+	_shape.end_update()
+
+
+func undo() -> void:
+	_shape.begin_update()
+	_shape.undo_cut_edge(_idx, _closing_key)
+	_shape.end_update()
+

--- a/addons/rmsmartshape/actions/action_cut_edge.gd
+++ b/addons/rmsmartshape/actions/action_cut_edge.gd
@@ -1,31 +1,42 @@
 extends SS2D_Action
 
 ## ActionCutEdge
+##
+## A delegate action that selects an action to perform based on the edge
+## location and shape state.
+
+var ActionOpenShape := preload("res://addons/rmsmartshape/actions/action_open_shape.gd")
+var ActionDeletePoint := preload("res://addons/rmsmartshape/actions/action_delete_point.gd")
+var ActionSplitShape := preload("res://addons/rmsmartshape/actions/action_split_shape.gd")
 
 var _shape: SS2D_Shape
-var _idx: int
-var _closing_key: int
+var _key: int
+var _action: SS2D_Action
 
 
-func _init(shape: SS2D_Shape, key: int) -> void:
+func _init(shape: SS2D_Shape, key_edge_start: int, key_edge_end: int) -> void:
 	_shape = shape
-	_idx = shape.get_point_index(key)
+
+	var key_first: int = shape.get_point_key_at_index(0)
+	var key_last: int = shape.get_point_key_at_index(shape.get_point_count()-1)
+	if _shape.is_shape_closed():
+		_action = ActionOpenShape.new(shape, key_edge_start)
+	elif key_edge_start == key_first:
+		_action = ActionDeletePoint.new(shape, key_edge_start)
+	elif  key_edge_end == key_last:
+		_action = ActionDeletePoint.new(shape, key_edge_end)
+	else:
+		_action = ActionSplitShape.new(shape, key_edge_start)
 
 
 func get_name() -> String:
-	return "Cut Edge"
+	return _action.get_name()
 
 
 func do() -> void:
-	_shape.begin_update()
-	var last_idx: int = _shape.get_point_count() - 1
-	_closing_key = _shape.get_point_key_at_index(last_idx)
-	_shape.cut_edge(_idx)
-	_shape.end_update()
+	_action.do()
 
 
 func undo() -> void:
-	_shape.begin_update()
-	_shape.undo_cut_edge(_idx, _closing_key)
-	_shape.end_update()
+	_action.undo()
 

--- a/addons/rmsmartshape/actions/action_cut_edge.gd
+++ b/addons/rmsmartshape/actions/action_cut_edge.gd
@@ -2,12 +2,12 @@ extends SS2D_Action
 
 ## ActionCutEdge
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _idx: int
 var _closing_key: int
 
 
-func _init(shape: SS2D_Shape_Base, key: int) -> void:
+func _init(shape: SS2D_Shape, key: int) -> void:
 	_shape = shape
 	_idx = shape.get_point_index(key)
 

--- a/addons/rmsmartshape/actions/action_delete_control_point.gd
+++ b/addons/rmsmartshape/actions/action_delete_control_point.gd
@@ -7,13 +7,13 @@ enum PointType {POINT_IN, POINT_OUT}
 const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
 var _invert_orientation: ActionInvertOrientation
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _key: int
 var _point_type: PointType
 var _old_value: Vector2
 
 
-func _init(shape: SS2D_Shape_Base, key: int, point_type: PointType) -> void:
+func _init(shape: SS2D_Shape, key: int, point_type: PointType) -> void:
 	_shape = shape
 	_key = key
 	_point_type = point_type

--- a/addons/rmsmartshape/actions/action_delete_point.gd
+++ b/addons/rmsmartshape/actions/action_delete_point.gd
@@ -19,6 +19,8 @@ var _points_out: PackedVector2Array
 var _properties: Array[SS2D_VertexProperties]
 var _constraints: Dictionary
 var _commit_update: bool
+var _was_closed: bool
+
 
 
 func _init(shape: SS2D_Shape_Base, key: int, commit_update: bool = true) -> void:
@@ -39,6 +41,7 @@ func get_name() -> String:
 
 func do() -> void:
 	_shape.begin_update()
+	_was_closed = _shape.is_shape_closed()
 	var first_run := _positions.size() == 0
 	for k in _keys:
 		if first_run:
@@ -48,7 +51,8 @@ func do() -> void:
 			_points_out.append(_shape.get_point_out(k))
 			_properties.append(_shape.get_point_properties(k))
 		_shape.remove_point(k)
-	_close_shape.do()
+	if _was_closed:
+		_close_shape.do()
 	_invert_orientation.do()
 	if _commit_update:
 		_shape.end_update()
@@ -57,7 +61,8 @@ func do() -> void:
 func undo() -> void:
 	_shape.begin_update()
 	_invert_orientation.undo()
-	_close_shape.undo()
+	if _was_closed:
+		_close_shape.undo()
 	for i in range(_keys.size()-1, -1, -1):
 		_shape.add_point(_positions[i], _indicies[i], _keys[i])
 		_shape.set_point_in(_keys[i], _points_in[i])

--- a/addons/rmsmartshape/actions/action_delete_point.gd
+++ b/addons/rmsmartshape/actions/action_delete_point.gd
@@ -10,7 +10,7 @@ var _invert_orientation: ActionInvertOrientation
 const ActionCloseShape := preload("res://addons/rmsmartshape/actions/action_close_shape.gd")
 var _close_shape: ActionCloseShape
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _keys: PackedInt64Array
 var _indicies: PackedInt64Array
 var _positions: PackedVector2Array
@@ -22,8 +22,7 @@ var _commit_update: bool
 var _was_closed: bool
 
 
-
-func _init(shape: SS2D_Shape_Base, key: int, commit_update: bool = true) -> void:
+func _init(shape: SS2D_Shape, key: int, commit_update: bool = true) -> void:
 	_shape = shape
 	_commit_update = commit_update
 	_invert_orientation = ActionInvertOrientation.new(shape)
@@ -74,7 +73,7 @@ func undo() -> void:
 	_shape.end_update()
 
 
-func get_constrained_points_to_delete(s: SS2D_Shape_Base, k: int, keys: PackedInt64Array = []) -> PackedInt64Array:
+func get_constrained_points_to_delete(s: SS2D_Shape, k: int, keys: PackedInt64Array = []) -> PackedInt64Array:
 	keys.push_back(k)
 	var constraints: Dictionary = s.get_point_constraints(k)
 	for tuple in constraints:

--- a/addons/rmsmartshape/actions/action_delete_point.gd
+++ b/addons/rmsmartshape/actions/action_delete_point.gd
@@ -1,87 +1,13 @@
-extends SS2D_Action
+extends "res://addons/rmsmartshape/actions/action_delete_points.gd"
 
 ## ActionDeletePoint
 
-const TUP := preload("res://addons/rmsmartshape/lib/tuple.gd")
-
-const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
-var _invert_orientation: ActionInvertOrientation
-
-const ActionCloseShape := preload("res://addons/rmsmartshape/actions/action_close_shape.gd")
-var _close_shape: ActionCloseShape
-
-var _shape: SS2D_Shape
-var _keys: PackedInt64Array
-var _indicies: PackedInt64Array
-var _positions: PackedVector2Array
-var _points_in: PackedVector2Array
-var _points_out: PackedVector2Array
-var _properties: Array[SS2D_VertexProperties]
-var _constraints: Dictionary
-var _commit_update: bool
-var _was_closed: bool
-
 
 func _init(shape: SS2D_Shape, key: int, commit_update: bool = true) -> void:
-	_shape = shape
-	_commit_update = commit_update
-	_invert_orientation = ActionInvertOrientation.new(shape)
-	_close_shape = ActionCloseShape.new(shape)
-
-	get_constrained_points_to_delete(shape, key, _keys)
-	# Save point constraints.
-	_constraints = _shape.get_point_constraints(key)
+	var keys: PackedInt64Array = [key]
+	super(shape, keys, commit_update)
 
 
 func get_name() -> String:
 	var pos := _shape.get_point_position(_keys[0])
 	return "Delete Point at (%d, %d)" % [pos.x, pos.y]
-
-
-func do() -> void:
-	_shape.begin_update()
-	_was_closed = _shape.is_shape_closed()
-	var first_run := _positions.size() == 0
-	for k in _keys:
-		if first_run:
-			_indicies.append(_shape.get_point_index(k))
-			_positions.append(_shape.get_point_position(k))
-			_points_in.append(_shape.get_point_in(k))
-			_points_out.append(_shape.get_point_out(k))
-			_properties.append(_shape.get_point_properties(k))
-		_shape.remove_point(k)
-	if _was_closed:
-		_close_shape.do()
-	_invert_orientation.do()
-	if _commit_update:
-		_shape.end_update()
-
-
-func undo() -> void:
-	_shape.begin_update()
-	_invert_orientation.undo()
-	if _was_closed:
-		_close_shape.undo()
-	for i in range(_keys.size()-1, -1, -1):
-		_shape.add_point(_positions[i], _indicies[i], _keys[i])
-		_shape.set_point_in(_keys[i], _points_in[i])
-		_shape.set_point_out(_keys[i], _points_out[i])
-		_shape.set_point_properties(_keys[i], _properties[i])
-	# Restore point constraints.
-	for tuple in _constraints:
-		_shape.set_constraint(tuple[0], tuple[1], _constraints[tuple])
-	_shape.end_update()
-
-
-func get_constrained_points_to_delete(s: SS2D_Shape, k: int, keys: PackedInt64Array = []) -> PackedInt64Array:
-	keys.push_back(k)
-	var constraints: Dictionary = s.get_point_constraints(k)
-	for tuple in constraints:
-		var constraint: SS2D_Point_Array.CONSTRAINT = constraints[tuple]
-		if constraint == SS2D_Point_Array.CONSTRAINT.NONE:
-			continue
-		var k2: int = TUP.get_other_value_from_tuple(tuple, k)
-		if constraint & SS2D_Point_Array.CONSTRAINT.ALL:
-			if not keys.has(k2):
-				get_constrained_points_to_delete(s, k2, keys)
-	return keys

--- a/addons/rmsmartshape/actions/action_delete_points.gd
+++ b/addons/rmsmartshape/actions/action_delete_points.gd
@@ -1,0 +1,85 @@
+extends SS2D_Action
+
+## ActionDeletePoints
+
+const TUP := preload("res://addons/rmsmartshape/lib/tuple.gd")
+
+const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
+var _invert_orientation: ActionInvertOrientation
+
+const ActionCloseShape := preload("res://addons/rmsmartshape/actions/action_close_shape.gd")
+var _close_shape: ActionCloseShape
+
+var _shape: SS2D_Shape
+var _keys: PackedInt64Array
+var _indicies: PackedInt64Array
+var _positions: PackedVector2Array
+var _points_in: PackedVector2Array
+var _points_out: PackedVector2Array
+var _properties: Array[SS2D_VertexProperties]
+var _constraints: Array[Dictionary]
+var _was_closed: bool
+
+
+func _init(shape: SS2D_Shape, keys: PackedInt64Array) -> void:
+	_shape = shape
+	_invert_orientation = ActionInvertOrientation.new(shape)
+	_close_shape = ActionCloseShape.new(shape)
+
+	for k in keys:
+		add_point_to_delete(k)
+
+
+func get_name() -> String:
+	var pos := _shape.get_point_position(_keys[0])
+	return "Delete Points %s" % [_keys]
+
+
+func do() -> void:
+	_shape.begin_update()
+	_was_closed = _shape.is_shape_closed()
+	var first_run := _positions.size() == 0
+	for k in _keys:
+		if first_run:
+			_indicies.append(_shape.get_point_index(k))
+			_positions.append(_shape.get_point_position(k))
+			_points_in.append(_shape.get_point_in(k))
+			_points_out.append(_shape.get_point_out(k))
+			_properties.append(_shape.get_point_properties(k))
+		_shape.remove_point(k)
+	if _was_closed:
+		_close_shape.do()
+	_invert_orientation.do()
+	_shape.end_update()
+
+
+func undo() -> void:
+	_shape.begin_update()
+	_invert_orientation.undo()
+	if _was_closed:
+		_close_shape.undo()
+	for i in range(_keys.size()-1, -1, -1):
+		_shape.add_point(_positions[i], _indicies[i], _keys[i])
+		_shape.set_point_in(_keys[i], _points_in[i])
+		_shape.set_point_out(_keys[i], _points_out[i])
+		_shape.set_point_properties(_keys[i], _properties[i])
+	# Restore point constraints.
+	for i in range(_keys.size()-1, -1, -1):
+		for tuple in _constraints[i]:
+			_shape.set_constraint(tuple[0], tuple[1], _constraints[i][tuple])
+	_shape.end_update()
+
+
+func add_point_to_delete(key: int) -> void:
+	_keys.push_back(key)
+	var constraints: Dictionary = _shape.get_point_constraints(key)
+	# Save point constraints.
+	_constraints.append(_shape.get_point_constraints(key))
+	for tuple in constraints:
+		var constraint: SS2D_Point_Array.CONSTRAINT = constraints[tuple]
+		if constraint == SS2D_Point_Array.CONSTRAINT.NONE:
+			continue
+		var key_other: int = TUP.get_other_value_from_tuple(tuple, key)
+		if constraint & SS2D_Point_Array.CONSTRAINT.ALL:
+			if not _keys.has(key_other):
+				add_point_to_delete(key_other)

--- a/addons/rmsmartshape/actions/action_delete_points.gd
+++ b/addons/rmsmartshape/actions/action_delete_points.gd
@@ -19,12 +19,14 @@ var _points_out: PackedVector2Array
 var _properties: Array[SS2D_VertexProperties]
 var _constraints: Array[Dictionary]
 var _was_closed: bool
+var _commit_update: bool
 
 
-func _init(shape: SS2D_Shape, keys: PackedInt64Array) -> void:
+func _init(shape: SS2D_Shape, keys: PackedInt64Array, commit_update: bool = true) -> void:
 	_shape = shape
 	_invert_orientation = ActionInvertOrientation.new(shape)
 	_close_shape = ActionCloseShape.new(shape)
+	_commit_update = commit_update
 
 	for k in keys:
 		add_point_to_delete(k)
@@ -50,7 +52,8 @@ func do() -> void:
 	if _was_closed:
 		_close_shape.do()
 	_invert_orientation.do()
-	_shape.end_update()
+	if _commit_update:
+		_shape.end_update()
 
 
 func undo() -> void:

--- a/addons/rmsmartshape/actions/action_invert_orientation.gd
+++ b/addons/rmsmartshape/actions/action_invert_orientation.gd
@@ -2,11 +2,11 @@ extends SS2D_Action
 
 ## ActionInvertOrientation
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _performed: bool
 
 
-func _init(shape: SS2D_Shape_Base) -> void:
+func _init(shape: SS2D_Shape) -> void:
 	_shape = shape
 
 
@@ -25,7 +25,7 @@ func undo() -> void:
 		_shape.invert_point_order()
 
 
-func should_invert_orientation(s: SS2D_Shape_Base) -> bool:
+func should_invert_orientation(s: SS2D_Shape) -> bool:
 	if s == null:
 		return false
 	if not s.is_shape_closed():

--- a/addons/rmsmartshape/actions/action_invert_orientation.gd
+++ b/addons/rmsmartshape/actions/action_invert_orientation.gd
@@ -28,6 +28,6 @@ func undo() -> void:
 func should_invert_orientation(s: SS2D_Shape_Base) -> bool:
 	if s == null:
 		return false
-	if s is SS2D_Shape_Open:
+	if not s.is_shape_closed():
 		return false
 	return not s.are_points_clockwise() and s.get_point_count() >= 3

--- a/addons/rmsmartshape/actions/action_make_shape_unique.gd
+++ b/addons/rmsmartshape/actions/action_make_shape_unique.gd
@@ -2,12 +2,12 @@ extends SS2D_Action
 
 ## ActionMakeShapeUnique
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _old_array: SS2D_Point_Array
 var _new_array: SS2D_Point_Array
 
 
-func _init(shape: SS2D_Shape_Base) -> void:
+func _init(shape: SS2D_Shape) -> void:
 	_shape = shape
 	_old_array = shape.get_point_array()
 	_new_array = _shape.get_point_array().clone(true)

--- a/addons/rmsmartshape/actions/action_move_control_points.gd
+++ b/addons/rmsmartshape/actions/action_move_control_points.gd
@@ -2,7 +2,7 @@ extends SS2D_Action
 
 ## ActionMoveControlPoints
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _keys: PackedInt64Array
 var _old_points_in: PackedVector2Array
 var _old_points_out: PackedVector2Array
@@ -10,7 +10,7 @@ var _new_points_in: PackedVector2Array
 var _new_points_out: PackedVector2Array
 
 
-func _init(s: SS2D_Shape_Base, keys: PackedInt64Array,
+func _init(s: SS2D_Shape, keys: PackedInt64Array,
 		old_points_in: PackedVector2Array, old_points_out: PackedVector2Array) -> void:
 	_shape = s
 	_keys = keys

--- a/addons/rmsmartshape/actions/action_move_verticies.gd
+++ b/addons/rmsmartshape/actions/action_move_verticies.gd
@@ -5,13 +5,13 @@ extends SS2D_Action
 const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/action_invert_orientation.gd")
 var _invert_orientation: ActionInvertOrientation
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _keys: PackedInt64Array
 var _old_positions: PackedVector2Array
 var _new_positions: PackedVector2Array
 
 
-func _init(s: SS2D_Shape_Base, keys: PackedInt64Array, old_positions: PackedVector2Array) -> void:
+func _init(s: SS2D_Shape, keys: PackedInt64Array, old_positions: PackedVector2Array) -> void:
 	_shape = s
 	_keys = keys.duplicate()
 	_old_positions = old_positions.duplicate()

--- a/addons/rmsmartshape/actions/action_open_shape.gd
+++ b/addons/rmsmartshape/actions/action_open_shape.gd
@@ -1,0 +1,31 @@
+extends SS2D_Action
+
+## ActionOpenShape
+
+var _shape: SS2D_Shape
+var _cut_idx: int
+var _closing_key: int
+
+
+func _init(shape: SS2D_Shape, edge_start_key: int) -> void:
+	_shape = shape
+	_cut_idx = shape.get_point_index(edge_start_key)
+
+
+func get_name() -> String:
+	return "Open Shape"
+
+
+func do() -> void:
+	_shape.begin_update()
+	var last_idx: int = _shape.get_point_count() - 1
+	_closing_key = _shape.get_point_key_at_index(last_idx)
+	_shape.open_shape_at_edge(_cut_idx)
+	_shape.end_update()
+
+
+func undo() -> void:
+	_shape.begin_update()
+	_shape.undo_open_shape_at_edge(_cut_idx, _closing_key)
+	_shape.end_update()
+

--- a/addons/rmsmartshape/actions/action_set_pivot.gd
+++ b/addons/rmsmartshape/actions/action_set_pivot.gd
@@ -2,12 +2,12 @@ extends SS2D_Action
 
 ## ActionSetPivot
 
-var _shape: SS2D_Shape_Base
+var _shape: SS2D_Shape
 var _old_pos: Vector2
 var _new_pos: Vector2
 
 
-func _init(s: SS2D_Shape_Base, et: Transform2D, pos: Vector2) -> void:
+func _init(s: SS2D_Shape, et: Transform2D, pos: Vector2) -> void:
 	_shape = s
 	_new_pos = pos
 	_old_pos = et * s.get_parent().get_global_transform() * s.position

--- a/addons/rmsmartshape/actions/action_split_curve.gd
+++ b/addons/rmsmartshape/actions/action_split_curve.gd
@@ -2,7 +2,7 @@ extends "res://addons/rmsmartshape/actions/action_add_point.gd"
 
 ## ActionSplitCurve
 
-func _init(shape: SS2D_Shape_Base, idx: int, gpoint: Vector2, xform: Transform2D, commit_update: bool = true) -> void:
+func _init(shape: SS2D_Shape, idx: int, gpoint: Vector2, xform: Transform2D, commit_update: bool = true) -> void:
 	super._init(shape, xform.affine_inverse() * gpoint, idx, commit_update)
 
 

--- a/addons/rmsmartshape/actions/action_split_shape.gd
+++ b/addons/rmsmartshape/actions/action_split_shape.gd
@@ -1,0 +1,74 @@
+extends SS2D_Action
+
+## ActionSplitShape
+##
+## How it's done:
+## 1. First, the shape is copied and added to the scene tree.
+## 2. Then, points of the splitted shape are deleted from first point to split point.
+## 3. Finally, points of the original shape are deleted from the point after split point to last point.
+
+const ActionDeletePoints := preload("res://addons/rmsmartshape/actions/action_delete_points.gd")
+var _delete_points_from_original: ActionDeletePoints
+
+var _shape: SS2D_Shape
+var _splitted: SS2D_Shape
+var _splitted_collision: CollisionPolygon2D
+var _split_idx: int
+
+
+func _init(shape: SS2D_Shape, split_point_key: int) -> void:
+	assert(shape.is_shape_closed() == false)
+	_shape = shape
+	_split_idx = shape.get_point_index(split_point_key)
+	_splitted = null
+	_splitted_collision = null
+	_delete_points_from_original = null
+
+
+func get_name() -> String:
+	return "Split Shape"
+
+
+func do() -> void:
+	if not is_instance_valid(_splitted):
+		_splitted = _shape.clone()
+		_splitted.begin_update()
+		for i in range(0, _split_idx + 1):
+			_splitted.remove_point_at_index(0)
+		_splitted.end_update()
+	_shape.get_parent().add_child(_splitted, true)
+	_splitted.set_owner(_shape.get_tree().get_edited_scene_root())
+	# Add a collision shape node if the original shape has one.
+	if (not _shape.collision_polygon_node_path.is_empty() and _shape.has_node(_shape.collision_polygon_node_path)):
+		var collision_polygon_original: Node = _shape.get_node(_shape.collision_polygon_node_path)
+		if not is_instance_valid(_splitted_collision):
+			_splitted_collision = CollisionPolygon2D.new()
+			_splitted_collision.visible = collision_polygon_original.visible
+			_splitted_collision.modulate = collision_polygon_original.modulate
+		collision_polygon_original.get_parent().add_child(_splitted_collision, true)
+		_splitted_collision.set_owner(collision_polygon_original.get_tree().get_edited_scene_root())
+		_splitted.collision_polygon_node_path = _splitted.get_path_to(_splitted_collision)
+
+	if _delete_points_from_original == null:
+		var delete_keys: PackedInt64Array
+		for i in range(_shape.get_point_count() - 1, _split_idx, -1):
+			delete_keys.append(_shape.get_point_key_at_index(i))
+		_delete_points_from_original = ActionDeletePoints.new(_shape, delete_keys)
+	_delete_points_from_original.do()
+
+
+func undo() -> void:
+	_splitted.set_owner(null)
+	_splitted.get_parent().remove_child(_splitted)
+	if is_instance_valid(_splitted_collision):
+		_splitted_collision.set_owner(null)
+		_splitted_collision.get_parent().remove_child(_splitted_collision)
+	_delete_points_from_original.undo()
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_PREDELETE:
+		if is_instance_valid(_splitted) and _splitted.get_parent() == null:
+			_splitted.queue_free()
+		if is_instance_valid(_splitted_collision) and _splitted_collision.get_parent() == null:
+			_splitted_collision.queue_free()

--- a/addons/rmsmartshape/editors/action_property_inspector_plugin.gd
+++ b/addons/rmsmartshape/editors/action_property_inspector_plugin.gd
@@ -1,7 +1,7 @@
 extends EditorInspectorPlugin
 
 ## This inspector plugin will show an Execute button for action properties in
-## SS2D_Shape_Base.
+## SS2D_Shape.
 ##
 ## To add an action property export it with:
 ##
@@ -33,7 +33,7 @@ class ActionPropertyEditor:
 
 
 func _can_handle(object: Object) -> bool:
-	if object is SS2D_Shape_Base:
+	if object is SS2D_Shape:
 		return true
 	return false
 

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -849,7 +849,8 @@ func draw_shape_outline(
 ) -> void:
 	if color == null:
 		color = shape.modulate
-	overlay.draw_polyline(t * points, color, width, true)
+	if points.size() >= 2:
+		overlay.draw_polyline(t * points, color, width, true)
 
 
 func draw_vert_handles(

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -100,7 +100,7 @@ class ActionDataVert:
 			return -1
 		return keys[0]
 
-	func current_point_index(s: SS2D_Shape_Base) -> int:
+	func current_point_index(s: SS2D_Shape) -> int:
 		if not is_single_vert_selected():
 			return -1
 		return s.get_point_index(keys[0])
@@ -117,7 +117,7 @@ var gui_snap_settings = GUI_SNAP_POPUP.instantiate()
 const GUI_POINT_INFO_PANEL_OFFSET := Vector2(256, 130)
 
 # This is the shape node being edited
-var shape: SS2D_Shape_Base = null
+var shape: SS2D_Shape = null
 
 # Toolbar Stuff
 var tb_hb: HBoxContainer = null
@@ -485,7 +485,7 @@ func _handles(object: Object) -> bool:
 	var selection: EditorSelection = get_editor_interface().get_selection()
 	if selection != null:
 		if selection.get_selected_nodes().size() == 1:
-			if selection.get_selected_nodes()[0] is SS2D_Shape_Base:
+			if selection.get_selected_nodes()[0] is SS2D_Shape:
 				hideToolbar = false
 
 	if hideToolbar == true:
@@ -494,7 +494,7 @@ func _handles(object: Object) -> bool:
 	if object is Resource:
 		return false
 
-	return object is SS2D_Shape_Base
+	return object is SS2D_Shape
 
 
 func _edit(object: Object) -> void:
@@ -606,7 +606,7 @@ func connect_shape(s) -> void:
 
 
 static func get_material_override_from_indicies(
-	s: SS2D_Shape_Base, indicies: Array
+	s: SS2D_Shape, indicies: Array
 ) -> SS2D_Material_Edge_Metadata:
 	var keys: Array[int] = []
 	for i in indicies:
@@ -676,7 +676,7 @@ static func is_shape_valid(s) -> bool:
 	return true
 
 
-func _on_shape_make_unique(_shape: SS2D_Shape_Base) -> void:
+func _on_shape_make_unique(_shape: SS2D_Shape) -> void:
 	make_unique_dialog.popup_centered()
 
 
@@ -688,7 +688,7 @@ func get_et() -> Transform2D:
 	return get_editor_interface().get_edited_scene_root().get_viewport().global_canvas_transform
 
 
-static func is_key_valid(s: SS2D_Shape_Base, key: int) -> bool:
+static func is_key_valid(s: SS2D_Shape, key: int) -> bool:
 	if not is_shape_valid(s):
 		return false
 	return s.has_point(key)
@@ -1102,7 +1102,7 @@ func _input_handle_left_click(
 			var idx: int = -1
 			if Input.is_key_pressed(KEY_SHIFT) and Input.is_key_pressed(KEY_ALT):
 				# Copy shape with a new single point
-				var copy: SS2D_Shape_Base = copy_shape(shape)
+				var copy: SS2D_Shape = copy_shape(shape)
 				copy.set_point_array(SS2D_Point_Array.new())
 				_enter_mode(MODE.CREATE_VERT)
 				var selection := get_editor_interface().get_selection()
@@ -1479,7 +1479,7 @@ func _input_motion_move_width_handle(mouse_position: Vector2, scale: Vector2) ->
 
 
 ## Will return index of closest vert to point.
-func get_closest_vert_to_point(s: SS2D_Shape_Base, p: Vector2) -> int:
+func get_closest_vert_to_point(s: SS2D_Shape, p: Vector2) -> int:
 	var gt: Transform2D = shape.get_global_transform()
 	var verts: PackedVector2Array = s.get_vertices()
 	var transformed_point: Vector2 = gt.affine_inverse() * p
@@ -1572,7 +1572,7 @@ func _input_handle_mouse_motion_event(
 				return true
 			else:
 				var xform: Transform2D = get_et() * shape.get_global_transform()
-				var closest_ss2d_point: SS2D_Point = (shape as SS2D_Shape_Base).get_point(closest_key)
+				var closest_ss2d_point: SS2D_Point = (shape as SS2D_Shape).get_point(closest_key)
 				if closest_ss2d_point != null:
 					var closest_point: Vector2 = closest_ss2d_point.position
 					closest_point = xform * closest_point
@@ -1599,12 +1599,9 @@ func _get_vert_normal(t: Transform2D, verts, i: int) -> Vector2:
 	return ((prev_point - point).normalized().rotated(PI / 2) + (point - next_point).normalized().rotated(PI / 2)).normalized()
 
 
-func copy_shape(s: SS2D_Shape_Base) -> SS2D_Shape_Base:
-	var copy: SS2D_Shape_Base
-	if s is SS2D_Shape_Closed:
-		copy = SS2D_Shape_Closed.new()
-	if s is SS2D_Shape_Open:
-		copy = SS2D_Shape_Open.new()
+func copy_shape(s: SS2D_Shape) -> SS2D_Shape:
+	var copy: SS2D_Shape
+	copy = SS2D_Shape.new()
 	copy.position = s.position
 	copy.scale = s.scale
 	copy.modulate = s.modulate

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -41,6 +41,7 @@ const ActionSplitCurve := preload("res://addons/rmsmartshape/actions/action_spli
 const ActionMakeShapeUnique := preload("res://addons/rmsmartshape/actions/action_make_shape_unique.gd")
 const ActionCutEdge := preload("res://addons/rmsmartshape/actions/action_cut_edge.gd")
 const ActionCloseShape := preload("res://addons/rmsmartshape/actions/action_close_shape.gd")
+const ActionSplitShape := preload("res://addons/rmsmartshape/actions/action_split_shape.gd")
 
 enum MODE { EDIT_VERT, EDIT_EDGE, CUT_EDGE, SET_PIVOT, CREATE_VERT, FREEHAND }
 
@@ -1138,18 +1139,7 @@ func _input_handle_left_click(
 			return true
 		var offset: float = shape.get_closest_offset_straight_edge(t.affine_inverse() * edge_point)
 		var edge_keys: Array[int] = _get_edge_point_keys_from_offset(offset, true)
-		if not shape.is_shape_closed():
-			var first_key: int = shape.get_point_key_at_index(0)
-			var last_key: int = shape.get_point_key_at_index(shape.get_point_count()-1)
-			if edge_keys[0] == first_key:
-				perform_action(ActionDeletePoint.new(shape, edge_keys[0]))
-			if edge_keys[1] == last_key:
-				perform_action(ActionDeletePoint.new(shape, edge_keys[1]))
-			if edge_keys[0] != first_key and edge_keys[1] != last_key:
-				# TODO: Implement splitting the shape into two shapes
-				push_warning("Currently, the Cut Edge Tool can't remove inner edges of an open shape.")
-			return true
-		perform_action(ActionCutEdge.new(shape, edge_keys[0]))
+		perform_action(ActionCutEdge.new(shape, edge_keys[0], edge_keys[1]))
 		return true
 	elif current_mode == MODE.FREEHAND:
 		return true
@@ -1596,22 +1586,7 @@ func _get_vert_normal(t: Transform2D, verts, i: int) -> Vector2:
 
 
 func copy_shape(s: SS2D_Shape) -> SS2D_Shape:
-	var copy: SS2D_Shape
-	copy = SS2D_Shape.new()
-	copy.position = s.position
-	copy.scale = s.scale
-	copy.modulate = s.modulate
-	copy.shape_material = s.shape_material
-	copy.editor_debug = s.editor_debug
-	copy.flip_edges = s.flip_edges
-	copy.editor_debug = s.editor_debug
-	copy.collision_size = s.collision_size
-	copy.collision_offset = s.collision_offset
-	copy.tessellation_stages = s.tessellation_stages
-	copy.tessellation_tolerence = s.tessellation_tolerence
-	copy.curve_bake_interval = s.curve_bake_interval
-	#copy.material_overrides = s.material_overrides
-	copy.name = s.get_name().rstrip("0123456789")
+	var copy: SS2D_Shape = s.clone(false)
 
 	var undo := get_undo_redo()
 	undo.create_action("Add Shape Node")

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -1562,12 +1562,8 @@ func _input_handle_mouse_motion_event(
 					last_point_position = local_position
 					if use_snap():
 						local_position = snap(local_position)
-					perform_action(ActionAddPoint.new(
-						shape,
-						local_position,
-						shape.get_point_index(closest_edge_keys[1]),
-						not _defer_mesh_updates
-					))
+					var idx: int = shape.get_point_index(closest_edge_keys[1]) if shape.is_shape_closed() else -1
+					perform_action(ActionAddPoint.new(shape, local_position, idx, not _defer_mesh_updates))
 				update_overlays()
 				return true
 			else:

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -1136,12 +1136,20 @@ func _input_handle_left_click(
 	elif current_mode == MODE.CUT_EDGE:
 		if not on_edge:
 			return true
-		if not shape.is_shape_closed():
-			push_warning("Currently, the Cut Edge Tool can't remove edges of an open shape.")
-			return true
 		var offset: float = shape.get_closest_offset_straight_edge(t.affine_inverse() * edge_point)
-		var edge_point_keys: Array[int] = _get_edge_point_keys_from_offset(offset, true)
-		perform_action(ActionCutEdge.new(shape, edge_point_keys[0]))
+		var edge_keys: Array[int] = _get_edge_point_keys_from_offset(offset, true)
+		if not shape.is_shape_closed():
+			var first_key: int = shape.get_point_key_at_index(0)
+			var last_key: int = shape.get_point_key_at_index(shape.get_point_count()-1)
+			if edge_keys[0] == first_key:
+				perform_action(ActionDeletePoint.new(shape, edge_keys[0]))
+			if edge_keys[1] == last_key:
+				perform_action(ActionDeletePoint.new(shape, edge_keys[1]))
+			if edge_keys[0] != first_key and edge_keys[1] != last_key:
+				# TODO: Implement splitting the shape into two shapes
+				push_warning("Currently, the Cut Edge Tool can't remove inner edges of an open shape.")
+			return true
+		perform_action(ActionCutEdge.new(shape, edge_keys[0]))
 		return true
 	elif current_mode == MODE.FREEHAND:
 		return true

--- a/addons/rmsmartshape/plugin_functionality.gd
+++ b/addons/rmsmartshape/plugin_functionality.gd
@@ -11,19 +11,19 @@ extends RefCounted
 # --- VERTS
 
 static func get_intersecting_control_point_in(
-	s: SS2D_Shape_Base, et: Transform2D, mouse_pos: Vector2, grab_threshold: float
+	s: SS2D_Shape, et: Transform2D, mouse_pos: Vector2, grab_threshold: float
 ) -> Array[int]:
 	return _get_intersecting_control_point(s, et, mouse_pos, grab_threshold, true)
 
 
 static func get_intersecting_control_point_out(
-	s: SS2D_Shape_Base, et: Transform2D, mouse_pos: Vector2, grab_threshold: float
+	s: SS2D_Shape, et: Transform2D, mouse_pos: Vector2, grab_threshold: float
 ) -> Array[int]:
 	return _get_intersecting_control_point(s, et, mouse_pos, grab_threshold, false)
 
 
 static func _get_intersecting_control_point(
-	s: SS2D_Shape_Base, et: Transform2D, mouse_pos: Vector2, grab_threshold: float, _in: bool
+	s: SS2D_Shape, et: Transform2D, mouse_pos: Vector2, grab_threshold: float, _in: bool
 ) -> Array[int]:
 	var points: Array[int] = []
 	var xform: Transform2D = et * s.get_global_transform()

--- a/addons/rmsmartshape/shapes/point_array.gd
+++ b/addons/rmsmartshape/shapes/point_array.gd
@@ -201,6 +201,7 @@ func set_point_index(key: int, idx: int) -> void:
 		return
 	_point_order.remove_at(old_idx)
 	_point_order.insert(idx, key)
+	_changed()
 
 
 func has_point(key: int) -> bool:

--- a/addons/rmsmartshape/shapes/point_array.gd
+++ b/addons/rmsmartshape/shapes/point_array.gd
@@ -140,7 +140,7 @@ func add_point(point: Vector2, idx: int = -1, use_key: int = -1) -> int:
 	if use_key == _next_key:
 		_next_key += 1
 	var new_point := SS2D_Point.new(point)
-	new_point.connect("changed", self._on_point_changed.bind(new_point))
+	new_point.connect(&"changed", self._on_point_changed.bind(new_point))
 	_points[use_key] = new_point
 	_point_order.push_back(use_key)
 	if idx != -1:
@@ -187,7 +187,22 @@ func get_point_index(key: int) -> int:
 
 
 func invert_point_order() -> void:
+	# Postpone `changed` and disable constraints.
+	var was_updating: bool = _updating
+	_updating = true
+	disable_constraints()
+
 	_point_order.reverse()
+	# Swap Bezier points.
+	for p in _points.values():
+		if p.point_out != p.point_in:
+			var tmp: Vector2 = p.point_out
+			p.point_out = p.point_in
+			p.point_in = tmp
+
+	# Re-enable contraits and emit `changed`.
+	enable_constraints()
+	_updating = was_updating
 	_changed()
 
 

--- a/addons/rmsmartshape/shapes/shape_anchor.gd
+++ b/addons/rmsmartshape/shapes/shape_anchor.gd
@@ -14,7 +14,7 @@ const DEBUG_DRAW_LINE_LENGTH := 128.0
 @export var debug_draw: bool = false : set = set_debug_draw
 
 var cached_shape_transform: Transform2D = Transform2D.IDENTITY
-var shape: SS2D_Shape_Base = null
+var shape: SS2D_Shape = null
 
 
 ###########
@@ -39,15 +39,15 @@ func set_shape() -> void:
 	shape = null
 	if has_node(shape_path):
 		var new_node: Node = get_node(shape_path)
-		if not new_node is SS2D_Shape_Base:
-			push_error("Shape Path isn't a valid subtype of SS2D_Shape_Base! Aborting...")
+		if not new_node is SS2D_Shape:
+			push_error("Shape Path isn't a valid subtype of SS2D_Shape! Aborting...")
 			return
 		shape = new_node
 		connect_shape(shape)
 		shape_point_index = get_shape_index_range(shape, shape_point_index)
 
 
-func get_shape_index_range(s: SS2D_Shape_Base, idx: int) -> int:
+func get_shape_index_range(s: SS2D_Shape, idx: int) -> int:
 	var point_count: int = s.get_point_count()
 	# Subtract 2;
 	#   'point_count' is out of bounds; subtract 1
@@ -133,12 +133,12 @@ func _cubic_bezier(p0: Vector2, p1: Vector2, p2: Vector2, p3: Vector2, t: float)
 	return s
 
 
-func disconnect_shape(s: SS2D_Shape_Base) -> void:
+func disconnect_shape(s: SS2D_Shape) -> void:
 	s.disconnect("points_modified", self._handle_point_change)
 	s.disconnect("tree_exiting", self._monitored_node_leaving)
 
 
-func connect_shape(s: SS2D_Shape_Base) -> void:
+func connect_shape(s: SS2D_Shape) -> void:
 	s.connect("points_modified", self._handle_point_change)
 	s.connect("tree_exiting", self._monitored_node_leaving)
 

--- a/addons/rmsmartshape/shapes/shape_closed.gd
+++ b/addons/rmsmartshape/shapes/shape_closed.gd
@@ -39,14 +39,14 @@ func _init() -> void:
 ############
 
 func _point_array_assigned() -> void:
-	close_shape()
-
-
-func has_minimum_point_count() -> bool:
-	return _points.get_point_count() > 3
+#	close_shape()
+	pass
 
 
 func _build_meshes(edges: Array[SS2D_Edge]) -> Array[SS2D_Mesh]:
+	if not is_shape_closed():
+		return super(edges)
+
 	var meshes: Array[SS2D_Mesh] = []
 
 	var produced_fill_mesh := false
@@ -226,6 +226,8 @@ func adjust_add_point_index(index: int) -> int:
 
 
 func generate_collision_points() -> PackedVector2Array:
+	if not is_shape_closed():
+		return super()
 	var points := PackedVector2Array()
 	var edge := _prepare_generate_collision_points(1.0)
 	# size of 1, has no meaning in a closed shape
@@ -251,10 +253,13 @@ func generate_collision_points() -> PackedVector2Array:
 ## Differs from the main get_meta_material_index_mapping
 ## in that the points wrap around.
 func _get_meta_material_index_mapping(s_material: SS2D_Material_Shape, verts: PackedVector2Array) -> Array[SS2D_IndexMap]:
-	return get_meta_material_index_mapping(s_material, verts, true)
+#	return get_meta_material_index_mapping(s_material, verts, true)
+	return get_meta_material_index_mapping(s_material, verts, is_shape_closed())
 
 
 func _merge_index_maps(imaps: Array[SS2D_IndexMap], verts: PackedVector2Array) -> Array[SS2D_IndexMap]:
+	if not is_shape_closed():
+		return super._merge_index_maps(imaps, verts)
 	# See if any edges have both the first (0) and last idx (size)
 	# Merge them into one if so
 	var final_edges: Array[SS2D_IndexMap] = imaps.duplicate()
@@ -291,4 +296,6 @@ func _imap_contains_all_points(imap: SS2D_IndexMap, verts: PackedVector2Array) -
 
 
 func _is_edge_contiguous(imap: SS2D_IndexMap, verts: PackedVector2Array) -> bool:
+	if not is_shape_closed():
+		return false
 	return _imap_contains_all_points(imap, verts)

--- a/addons/rmsmartshape/shapes/shape_closed.gd
+++ b/addons/rmsmartshape/shapes/shape_closed.gd
@@ -1,301 +1,58 @@
 @tool
 @icon("../assets/closed_shape.png")
-extends SS2D_Shape_Base
+extends SS2D_Shape
 class_name SS2D_Shape_Closed
 
-##########
-# CLOSED #
-##########
+## DEPRECATED: Use [SS2D_Shape] instead.
 
-# A Hole is a closed polygon
-# Orientation doesn't matter
-# Holes should not intersect each other
-
-# FIXME: unused member.
-#var _holes = []
-
-
-# FIXME: unused method.
-#func set_holes(holes: Array):
-#	_holes = holes
-
-
-# FIXME: unused method.
-#func get_holes() -> Array:
-#	return _holes
-
-
-#########
-# GODOT #
-#########
-
-func _init() -> void:
-	super._init()
-	_is_instantiable = true
-
-
-############
-# OVERRIDE #
-############
-
-func _point_array_assigned() -> void:
-#	close_shape()
-	pass
-
-
-func _build_meshes(edges: Array[SS2D_Edge]) -> Array[SS2D_Mesh]:
-	if not is_shape_closed():
-		return super(edges)
-
-	var meshes: Array[SS2D_Mesh] = []
-
-	var produced_fill_mesh := false
-	for e in edges:
-		if not produced_fill_mesh:
-			if e.z_index > shape_material.fill_texture_z_index:
-				# Produce Fill Meshes
-				for m in _build_fill_mesh(get_tessellated_points(), shape_material):
-					meshes.push_back(m)
-				produced_fill_mesh = true
-
-		# Produce edge Meshes
-		for m in e.get_meshes(color_encoding):
-			meshes.push_back(m)
-	if not produced_fill_mesh:
-		for m in _build_fill_mesh(get_tessellated_points(), shape_material):
-			meshes.push_back(m)
-		produced_fill_mesh = true
-	return meshes
-
+# UNUSED FUNCTIONS:
 
 ## Returns true if line segment 'a1a2' and 'b1b2' intersect.[br]
 ## Find the four orientations needed for general and special cases.[br]
-func do_edges_intersect(a1: Vector2, a2: Vector2, b1: Vector2, b2: Vector2) -> bool:
-	var o1: int = get_points_orientation([a1, a2, b1])
-	var o2: int = get_points_orientation([a1, a2, b2])
-	var o3: int = get_points_orientation([b1, b2, a1])
-	var o4: int = get_points_orientation([b1, b2, a2])
-
-	# General case
-	if o1 != o2 and o3 != o4:
-		return true
-
-	# Special Cases
-	# a1, a2 and b1 are colinear and b1 lies on segment p1q1
-	if o1 == ORIENTATION.COLINEAR and on_segment(a1, b1, a2):
-		return true
-
-	# a1, a2 and b2 are colinear and b2 lies on segment p1q1
-	if o2 == ORIENTATION.COLINEAR and on_segment(a1, b2, a2):
-		return true
-
-	# b1, b2 and a1 are colinear and a1 lies on segment p2q2
-	if o3 == ORIENTATION.COLINEAR and on_segment(b1, a1, b2):
-		return true
-
-	# b1, b2 and a2 are colinear and a2 lies on segment p2q2
-	if o4 == ORIENTATION.COLINEAR and on_segment(b1, a2, b2):
-		return true
-
-	# Doesn't fall in any of the above cases
-	return false
-
-
-static func get_edge_intersection(a1: Vector2, a2: Vector2, b1: Vector2, b2: Vector2) -> Variant:
-	var den: float = (b2.y - b1.y) * (a2.x - a1.x) - (b2.x - b1.x) * (a2.y - a1.y)
-
-	# Check if lines are parallel or coincident
-	if den == 0:
-		return null
-
-	var ua: float = ((b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)) / den
-	var ub: float = ((a2.x - a1.x) * (a1.y - b1.y) - (a2.y - a1.y) * (a1.x - b1.x)) / den
-
-	if ua < 0 or ub < 0 or ua > 1 or ub > 1:
-		return null
-
-	return Vector2(a1.x + ua * (a2.x - a1.x), a1.y + ua * (a2.y - a1.y))
+#func do_edges_intersect(a1: Vector2, a2: Vector2, b1: Vector2, b2: Vector2) -> bool:
+#	var o1: int = get_points_orientation([a1, a2, b1])
+#	var o2: int = get_points_orientation([a1, a2, b2])
+#	var o3: int = get_points_orientation([b1, b2, a1])
+#	var o4: int = get_points_orientation([b1, b2, a2])
+#
+#	# General case
+#	if o1 != o2 and o3 != o4:
+#		return true
+#
+#	# Special Cases
+#	# a1, a2 and b1 are colinear and b1 lies on segment p1q1
+#	if o1 == ORIENTATION.COLINEAR and on_segment(a1, b1, a2):
+#		return true
+#
+#	# a1, a2 and b2 are colinear and b2 lies on segment p1q1
+#	if o2 == ORIENTATION.COLINEAR and on_segment(a1, b2, a2):
+#		return true
+#
+#	# b1, b2 and a1 are colinear and a1 lies on segment p2q2
+#	if o3 == ORIENTATION.COLINEAR and on_segment(b1, a1, b2):
+#		return true
+#
+#	# b1, b2 and a2 are colinear and a2 lies on segment p2q2
+#	if o4 == ORIENTATION.COLINEAR and on_segment(b1, a2, b2):
+#		return true
+#
+#	# Doesn't fall in any of the above cases
+#	return false
 
 
-func _build_fill_mesh(points: PackedVector2Array, s_mat: SS2D_Material_Shape) -> Array[SS2D_Mesh]:
-	var meshes: Array[SS2D_Mesh] = []
-	if s_mat == null:
-		return meshes
-	if s_mat.fill_textures.is_empty():
-		return meshes
-	if points.size() < 3:
-		return meshes
-
-	var tex: Texture2D = null
-	if s_mat.fill_textures.is_empty():
-		return meshes
-	tex = s_mat.fill_textures[0]
-	var tex_size: Vector2 = tex.get_size()
-
-	# Points to produce the fill mesh
-	var fill_points: PackedVector2Array = PackedVector2Array()
-	var polygons: Array[PackedVector2Array] = Geometry2D.offset_polygon(
-		PackedVector2Array(points), tex_size.x * s_mat.fill_mesh_offset
-	)
-	points = polygons[0]
-	fill_points.resize(points.size())
-	for i in range(points.size()):
-		fill_points[i] = points[i]
-
-	# Produce the fill mesh
-	var fill_tris: PackedInt32Array = Geometry2D.triangulate_polygon(fill_points)
-	if fill_tris.is_empty():
-		push_error("'%s': Couldn't Triangulate shape" % name)
-		return []
-
-	var st: SurfaceTool
-	st = SurfaceTool.new()
-	st.begin(Mesh.PRIMITIVE_TRIANGLES)
-
-	for i in range(0, fill_tris.size() - 1, 3):
-		st.set_color(Color.WHITE)
-		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(points[fill_tris[i]], tex_size))
-		st.add_vertex(Vector3(points[fill_tris[i]].x, points[fill_tris[i]].y, 0))
-		st.set_color(Color.WHITE)
-		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(points[fill_tris[i + 1]], tex_size))
-		st.add_vertex(Vector3(points[fill_tris[i + 1]].x, points[fill_tris[i + 1]].y, 0))
-		st.set_color(Color.WHITE)
-		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(points[fill_tris[i + 2]], tex_size))
-		st.add_vertex(Vector3(points[fill_tris[i + 2]].x, points[fill_tris[i + 2]].y, 0))
-	st.index()
-	st.generate_normals()
-	st.generate_tangents()
-	var array_mesh := st.commit()
-	var flip := false
-	var trans := Transform2D()
-	var mesh_data := SS2D_Mesh.new(tex, flip, trans, [array_mesh])
-	mesh_data.material = s_mat.fill_mesh_material
-	mesh_data.z_index = s_mat.fill_texture_z_index
-	mesh_data.z_as_relative = true
-	mesh_data.show_behind_parent = s_mat.fill_texture_show_behind_parent
-	meshes.push_back(mesh_data)
-
-	return meshes
+#static func get_edge_intersection(a1: Vector2, a2: Vector2, b1: Vector2, b2: Vector2) -> Variant:
+#	var den: float = (b2.y - b1.y) * (a2.x - a1.x) - (b2.x - b1.x) * (a2.y - a1.y)
+#
+#	# Check if lines are parallel or coincident
+#	if den == 0:
+#		return null
+#
+#	var ua: float = ((b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)) / den
+#	var ub: float = ((a2.x - a1.x) * (a1.y - b1.y) - (a2.y - a1.y) * (a1.x - b1.x)) / den
+#
+#	if ua < 0 or ub < 0 or ua > 1 or ub > 1:
+#		return null
+#
+#	return Vector2(a1.x + ua * (a2.x - a1.x), a1.y + ua * (a2.y - a1.y))
 
 
-## Is this shape not yet closed but should be?
-func can_close() -> bool:
-	return _points.get_point_count() > 2 and _has_closing_point() == false
-
-
-## Will mutate the _points to ensure this is a closed_shape.[br]
-## Last point will be constrained to first point.[br]
-## Returns key of a point used to close the shape.[br]
-## [param key] suggests which key to use instead of auto-generated.[br]
-func close_shape(key: int = -1) -> int:
-	if not can_close():
-		return -1
-
-	var key_first: int = _points.get_point_key_at_index(0)
-	var key_last: int = _points.get_point_key_at_index(_points.get_point_count() - 1)
-
-	if get_point_position(key_first) != get_point_position(key_last):
-		key_last = _points.add_point(_points.get_point_position(key_first), -1, key)
-	_points.set_constraint(key_first, key_last, SS2D_Point_Array.CONSTRAINT.ALL)
-
-	return key_last
-
-
-func is_shape_closed() -> bool:
-	if _points.get_point_count() < 4:
-		return false
-	return _has_closing_point()
-
-
-func _has_closing_point() -> bool:
-	if _points.get_point_count() < 2:
-		return false
-	var key1: int = _points.get_point_key_at_index(0)
-	var key2: int = _points.get_point_key_at_index(_points.get_point_count() - 1)
-	return get_point_constraint(key1, key2) == SS2D_Point_Array.CONSTRAINT.ALL
-
-
-func adjust_add_point_index(index: int) -> int:
-	# Don't allow a point to be added after the last point of the closed shape or before the first
-	if _has_closing_point():
-		if index < 0 or (index > get_point_count() - 1):
-			index = maxi(get_point_count() - 1, 0)
-		if index < 1:
-			index = 1
-	return index
-
-
-func generate_collision_points() -> PackedVector2Array:
-	if not is_shape_closed():
-		return super()
-	var points := PackedVector2Array()
-	var edge := _prepare_generate_collision_points(1.0)
-	# size of 1, has no meaning in a closed shape
-
-	if not edge:
-		return points
-
-	var first_quad: SS2D_Quad = edge.quads[0]
-	var last_quad: SS2D_Quad = edge.quads.back()
-	weld_quads(last_quad, first_quad, 1.0)
-
-	if not edge.quads.is_empty():
-		for quad in edge.quads:
-			if quad.corner == SS2D_Quad.CORNER.NONE:
-				points.push_back(quad.pt_a)
-			elif quad.corner == SS2D_Quad.CORNER.OUTER:
-				points.push_back(quad.pt_d)
-			elif quad.corner == SS2D_Quad.CORNER.INNER:
-				pass
-	return points
-
-
-## Differs from the main get_meta_material_index_mapping
-## in that the points wrap around.
-func _get_meta_material_index_mapping(s_material: SS2D_Material_Shape, verts: PackedVector2Array) -> Array[SS2D_IndexMap]:
-#	return get_meta_material_index_mapping(s_material, verts, true)
-	return get_meta_material_index_mapping(s_material, verts, is_shape_closed())
-
-
-func _merge_index_maps(imaps: Array[SS2D_IndexMap], verts: PackedVector2Array) -> Array[SS2D_IndexMap]:
-	if not is_shape_closed():
-		return super._merge_index_maps(imaps, verts)
-	# See if any edges have both the first (0) and last idx (size)
-	# Merge them into one if so
-	var final_edges: Array[SS2D_IndexMap] = imaps.duplicate()
-	var edges_by_material: Dictionary = SS2D_IndexMap.index_map_array_sort_by_object(final_edges)
-	# Erase any with null material
-	edges_by_material.erase(null)
-	for mat in edges_by_material:
-		var edge_first_idx: SS2D_IndexMap = null
-		var edge_last_idx: SS2D_IndexMap = null
-		for e in edges_by_material[mat]:
-			if e.indicies.has(0):
-				edge_first_idx = e
-			if e.indicies.has(verts.size()-1):
-				edge_last_idx = e
-			if edge_first_idx != null and edge_last_idx != null:
-				break
-		if edge_first_idx != null and edge_last_idx != null:
-			if edge_first_idx == edge_last_idx:
-				pass
-			else:
-				final_edges.erase(edge_last_idx)
-				final_edges.erase(edge_first_idx)
-				var indicies: Array[int] = []
-				indicies.append_array(edge_last_idx.indicies)
-				indicies.append_array(edge_first_idx.indicies)
-				var merged_edge := SS2D_IndexMap.new(indicies, mat)
-				final_edges.push_back(merged_edge)
-
-	return final_edges
-
-
-func _imap_contains_all_points(imap: SS2D_IndexMap, verts: PackedVector2Array) -> bool:
-	return imap.indicies[0] == 0 and imap.indicies.back() == verts.size()-1
-
-
-func _is_edge_contiguous(imap: SS2D_IndexMap, verts: PackedVector2Array) -> bool:
-	if not is_shape_closed():
-		return false
-	return _imap_contains_all_points(imap, verts)

--- a/addons/rmsmartshape/shapes/shape_closed.gd
+++ b/addons/rmsmartshape/shapes/shape_closed.gd
@@ -2,8 +2,8 @@
 @icon("../assets/closed_shape.png")
 extends SS2D_Shape
 class_name SS2D_Shape_Closed
-
 ## DEPRECATED: Use [SS2D_Shape] instead.
+## @deprecated
 
 # UNUSED FUNCTIONS:
 

--- a/addons/rmsmartshape/shapes/shape_open.gd
+++ b/addons/rmsmartshape/shapes/shape_open.gd
@@ -1,20 +1,6 @@
 @tool
 @icon("../assets/open_shape.png")
-extends SS2D_Shape_Base
+extends SS2D_Shape
 class_name SS2D_Shape_Open
 
-
-#########
-# GODOT #
-#########
-func _init() -> void:
-	super._init()
-	_is_instantiable = true
-
-
-
-############
-# OVERRIDE #
-############
-func should_flip_edges() -> bool:
-	return flip_edges
+## DEPRECATED: Use [SS2D_Shape] instead.

--- a/addons/rmsmartshape/shapes/shape_open.gd
+++ b/addons/rmsmartshape/shapes/shape_open.gd
@@ -4,3 +4,4 @@ extends SS2D_Shape
 class_name SS2D_Shape_Open
 
 ## DEPRECATED: Use [SS2D_Shape] instead.
+## @deprecated

--- a/addons/rmsmartshape/strings.gd
+++ b/addons/rmsmartshape/strings.gd
@@ -5,7 +5,7 @@ class_name SS2D_Strings
 const EN_TOOLTIP_CREATE_VERT := "Create Vertices Tool\nLMB: Add vertex\nShift+LMB: Create Bezier curve using Control Points\nControl+LMB: Set Pivot Point\nLMB+Drag: Move Point\nLMB: Click on edge to split\nRMB: Delete Point"
 const EN_TOOLTIP_EDIT_VERT := "Edit Vertices Tool\nShift+LMB: Create Bezier curve using Control Points\nAlt+LMB: Add vertex\nControl+LMB: Set Pivot Point\nLMB+Drag: Move Point\nLMB: Click on edge to split\nRMB: Delete Point"
 const EN_TOOLTIP_EDIT_EDGE := "Edit Edge Tool\nSelect each edge's properties"
-const EN_TOOLTIP_CUT_EDGE := "Cut Edge Tool\nRemove the edge between vertices to open the shape.\nCurrently, it only works when the shape is closed."
+const EN_TOOLTIP_CUT_EDGE := "Cut Edge Tool\nRemoves the edge between vertices, opening the shape.\nCan be used to split the shape into two separate shapes."
 const EN_TOOLTIP_FREEHAND := "Freehand Tool\nHold LMB: Add vertices along the drag line.\nControl+LMB: remove vertices inside the circle while dragging.\nShift+Mousewheel: Change circle size for drawing.\nShift+Control+Mousewheel: Change circle size for eraser."
 const EN_TOOLTIP_PIVOT := "Set Pivot Tool\nSets the origin of the shape"
 const EN_TOOLTIP_COLLISION := "Collision Tool\nAdd static body parent and collision polygon sibling\nUse this to auto generate collision Nodes"

--- a/addons/rmsmartshape/strings.gd
+++ b/addons/rmsmartshape/strings.gd
@@ -2,14 +2,14 @@
 extends Resource
 class_name SS2D_Strings
 
-const EN_TOOLTIP_CREATE_VERT := "LMB: Add vertex\nShift+LMB: Create Bezier curve using Control Points\nControl+LMB: Set Pivot Point\nLMB+Drag: Move Point\nLMB: Click on edge to split\nRMB: Delete Point"
-const EN_TOOLTIP_EDIT_VERT := "Shift+LMB: Create Bezier curve using Control Points\nAlt+LMB: Add vertex\nControl+LMB: Set Pivot Point\nLMB+Drag: Move Point\nLMB: Click on edge to split\nRMB: Delete Point"
-const EN_TOOLTIP_EDIT_EDGE := "Select each edge's properties"
-const EN_TOOLTIP_FREEHAND := "Hold LMB: Add vertices along the drag line.\nControl+LMB: remove vertices inside the circle while dragging.\nShift+Mousewheel: Change circle size for drawing.\nShift+Control+Mousewheel: Change circle size for eraser."
-const EN_TOOLTIP_PIVOT := "Sets the origin of the shape"
-const EN_TOOLTIP_COLLISION := "Add static body parent and collision polygon sibling\nUse this to auto generate collision Nodes"
+const EN_TOOLTIP_CREATE_VERT := "Create Vertices Tool\nLMB: Add vertex\nShift+LMB: Create Bezier curve using Control Points\nControl+LMB: Set Pivot Point\nLMB+Drag: Move Point\nLMB: Click on edge to split\nRMB: Delete Point"
+const EN_TOOLTIP_EDIT_VERT := "Edit Vertices Tool\nShift+LMB: Create Bezier curve using Control Points\nAlt+LMB: Add vertex\nControl+LMB: Set Pivot Point\nLMB+Drag: Move Point\nLMB: Click on edge to split\nRMB: Delete Point"
+const EN_TOOLTIP_EDIT_EDGE := "Edit Edge Tool\nSelect each edge's properties"
+const EN_TOOLTIP_CUT_EDGE := "Cut Edge Tool\nRemove the edge between vertices to open the shape.\nCurrently, it only works when the shape is closed."
+const EN_TOOLTIP_FREEHAND := "Freehand Tool\nHold LMB: Add vertices along the drag line.\nControl+LMB: remove vertices inside the circle while dragging.\nShift+Mousewheel: Change circle size for drawing.\nShift+Control+Mousewheel: Change circle size for eraser."
+const EN_TOOLTIP_PIVOT := "Set Pivot Tool\nSets the origin of the shape"
+const EN_TOOLTIP_COLLISION := "Collision Tool\nAdd static body parent and collision polygon sibling\nUse this to auto generate collision Nodes"
 const EN_TOOLTIP_SNAP := "Snapping Options"
-const EN_TOOLTIP_IMPORT := "Convert old Smartshape to new Smartshape"
 const EN_TOOLTIP_MORE_OPTIONS := "More Options"
 
 const EN_OPTIONS_DEFER_MESH_UPDATES := "Defer Mesh Updates"

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="SmartShape2D"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.png"
 
 [editor_plugins]

--- a/tests/unit/test_anchor.gd
+++ b/tests/unit/test_anchor.gd
@@ -61,8 +61,8 @@ func generate_closed_shape() -> SS2D_Shape_Closed:
 	return shape
 
 
-func generate_open_shape() -> SS2D_Shape_Open:
-	var shape = SS2D_Shape_Open.new()
+func generate_open_shape() -> SS2D_Shape:
+	var shape = SS2D_Shape.new()
 	shape.name = "Open"
 	add_child_autofree(shape)
 	var points = generate_points()

--- a/tests/unit/test_plugin_actions.gd
+++ b/tests/unit/test_plugin_actions.gd
@@ -266,7 +266,7 @@ func test_action_split_curve() -> void:
 	validate_positions(s, [Vector2(0, 0), Vector2(50, 50), Vector2(100, 100)])
 
 
-func validate_positions(s: SS2D_Shape_Base, positions: PackedVector2Array) -> void:
+func validate_positions(s: SS2D_Shape, positions: PackedVector2Array) -> void:
 	assert_eq(s.get_point_count(), positions.size())
 	if s.get_point_count() != positions.size():
 		return

--- a/tests/unit/test_plugin_actions.gd
+++ b/tests/unit/test_plugin_actions.gd
@@ -9,8 +9,10 @@ const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/acti
 const ActionMakeShapeUnique := preload("res://addons/rmsmartshape/actions/action_make_shape_unique.gd")
 const ActionMoveControlPoints := preload("res://addons/rmsmartshape/actions/action_move_control_points.gd")
 const ActionMoveVerticies := preload("res://addons/rmsmartshape/actions/action_move_verticies.gd")
+const ActionOpenShape := preload("res://addons/rmsmartshape/actions/action_open_shape.gd")
 const ActionSetPivot := preload("res://addons/rmsmartshape/actions/action_set_pivot.gd")
 const ActionSplitCurve := preload("res://addons/rmsmartshape/actions/action_split_curve.gd")
+const ActionSplitShape := preload("res://addons/rmsmartshape/actions/action_split_shape.gd")
 
 
 func test_action_add_collision_nodes() -> void:
@@ -30,7 +32,7 @@ func test_action_add_collision_nodes() -> void:
 
 
 func test_action_add_point() -> void:
-	var s := SS2D_Shape_Closed.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(s)
 
 	s.add_point(Vector2(0.0, 0.0))
@@ -48,17 +50,17 @@ func test_action_add_point() -> void:
 	validate_positions(s, [Vector2(0.0, 0.0), Vector2(100.0, 0.0)])
 
 	assert_false(s.is_shape_closed())
+
 	var add_point_2 := ActionAddPoint.new(s, Vector2(100.0, 100.0))
 	add_point_2.do()
-	assert_eq(s.get_point_count(), 4)  ## shape should be closed by this action - so 4 points
-	assert_true(s.is_shape_closed())
+	assert_eq(s.get_point_count(), 3)
+	assert_false(s.is_shape_closed())
 	add_point_2.undo()
 	assert_eq(s.get_point_count(), 2)
 	add_point_2.do()
-	assert_eq(s.get_point_count(), 4)
+	assert_eq(s.get_point_count(), 3)
 
-	validate_positions(s, [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 100.0),
-			Vector2(0.0, 0.0)])
+	validate_positions(s, [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 100.0)])
 
 
 func test_action_close_shape() -> void:
@@ -108,7 +110,7 @@ func test_action_delete_control_point() -> void:
 
 
 func test_action_delete_point() -> void:
-	var s := SS2D_Shape_Closed.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(s)
 
 	s.add_points([Vector2.UP, Vector2.RIGHT])
@@ -146,15 +148,17 @@ func test_action_delete_point() -> void:
 
 
 func test_action_invert_orientation() -> void:
-	var s := SS2D_Shape_Closed.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(s)
 
 	var a := ActionInvertOrientation.new(s)
 	var cw_sequence := [Vector2.UP, Vector2.RIGHT, Vector2.DOWN, Vector2.LEFT]
-	var ccw_sequence := [Vector2.LEFT, Vector2.DOWN, Vector2.RIGHT, Vector2.UP]
+	var ccw_sequence := [Vector2.UP, Vector2.LEFT, Vector2.DOWN, Vector2.RIGHT]
 
 	# Test with clockwise sequence.
 	s.add_points(cw_sequence)
+	s.close_shape()
+	cw_sequence.push_back(cw_sequence.front())
 	validate_positions(s, cw_sequence)
 	a.do()
 	validate_positions(s, cw_sequence)
@@ -164,6 +168,8 @@ func test_action_invert_orientation() -> void:
 	# Test with counter-clockwise sequence.
 	s.clear_points()
 	s.add_points(ccw_sequence)
+	ccw_sequence.push_back(ccw_sequence.front())
+	s.close_shape()
 	validate_positions(s, ccw_sequence)
 	a.do()
 	validate_positions(s, cw_sequence)
@@ -172,7 +178,7 @@ func test_action_invert_orientation() -> void:
 
 
 func test_action_make_shape_unique() -> void:
-	var s := SS2D_Shape_Closed.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(s)
 
 	var original_array := SS2D_Point_Array.new()
@@ -194,7 +200,7 @@ func test_action_make_shape_unique() -> void:
 
 
 func test_action_move_control_points() -> void:
-	var s := SS2D_Shape_Closed.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(s)
 
 	# Setup.
@@ -218,7 +224,7 @@ func test_action_move_control_points() -> void:
 
 
 func test_action_move_verticies() -> void:
-	var s := SS2D_Shape_Closed.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(s)
 
 	var new_positions := [Vector2.UP, Vector2.RIGHT, Vector2.DOWN]
@@ -236,7 +242,7 @@ func test_action_move_verticies() -> void:
 
 func test_action_set_pivot() -> void:
 	var parent := Node2D.new()
-	var s := SS2D_Shape_Closed.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(parent)
 	parent.add_child(s)
 
@@ -251,7 +257,7 @@ func test_action_set_pivot() -> void:
 
 
 func test_action_split_curve() -> void:
-	var s := SS2D_Shape_Open.new()
+	var s := SS2D_Shape.new()
 	add_child_autofree(s)
 
 	var t := Transform2D()
@@ -264,6 +270,42 @@ func test_action_split_curve() -> void:
 	validate_positions(s, [Vector2(0, 0), Vector2(100, 100)])
 	action.do()
 	validate_positions(s, [Vector2(0, 0), Vector2(50, 50), Vector2(100, 100)])
+
+
+func test_action_open_shape() -> void:
+	var s := SS2D_Shape.new()
+	add_child_autofree(s)
+
+	s.add_points([Vector2.UP, Vector2.RIGHT, Vector2.DOWN, Vector2.LEFT])
+	s.close_shape()
+
+	var action := ActionOpenShape.new(s, s.get_point_key_at_index(1))
+	action.do()
+	validate_positions(s, [Vector2.DOWN, Vector2.LEFT, Vector2.UP, Vector2.RIGHT])
+	action.undo()
+	validate_positions(s, [Vector2.UP, Vector2.RIGHT, Vector2.DOWN, Vector2.LEFT, Vector2.UP])
+
+
+func test_action_split_shape() -> void:
+	var s := SS2D_Shape.new()
+	s.name = "Shape"
+	add_child_autofree(s, true)
+
+	s.add_points([Vector2.UP, Vector2.RIGHT, Vector2.DOWN, Vector2.LEFT])
+	validate_positions(s, [Vector2.UP, Vector2.RIGHT, Vector2.DOWN, Vector2.LEFT])
+
+	var action := ActionSplitShape.new(s, s.get_point_key_at_index(1))
+	action.do()
+	assert_eq(s.get_parent().get_child_count(), 2)
+	validate_positions(s, [Vector2.UP, Vector2.RIGHT])
+	var s2: SS2D_Shape = s.get_parent().get_node(^"Shape2")
+	assert_not_null(s2)
+	add_child_autofree(s2, true)
+	validate_positions(s2, [Vector2.DOWN, Vector2.LEFT])
+
+	action.undo()
+	assert_eq(s.get_parent().get_child_count(), 1)
+	validate_positions(s, [Vector2.UP, Vector2.RIGHT, Vector2.DOWN, Vector2.LEFT])
 
 
 func validate_positions(s: SS2D_Shape, positions: PackedVector2Array) -> void:

--- a/tests/unit/test_shape_base.gd
+++ b/tests/unit/test_shape_base.gd
@@ -146,7 +146,6 @@ func test_build_edge_with_material_basic_square(offset = use_parameters(offset_p
 	var shape_material = create_shape_material_with_equal_normal_ranges(4, tex)
 	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
-	shape._is_instantiable = true
 	shape.shape_material = shape_material
 	shape.set_point_array(point_array)
 

--- a/tests/unit/test_shape_base.gd
+++ b/tests/unit/test_shape_base.gd
@@ -34,23 +34,23 @@ func test_tessellated_idx_and_point_idx():
 		Vector2(0, 12), # 5 (2)
 		Vector2(-10, 10) # 6 (3)
 	]
-	assert_eq(SS2D_Shape_Base.get_tessellated_idx_from_point(verts, t_verts, 0), 0)
-	assert_eq(SS2D_Shape_Base.get_tessellated_idx_from_point(verts, t_verts, 1), 2)
-	assert_eq(SS2D_Shape_Base.get_tessellated_idx_from_point(verts, t_verts, 2), 4)
-	assert_eq(SS2D_Shape_Base.get_tessellated_idx_from_point(verts, t_verts, 3), 6)
-	assert_eq(SS2D_Shape_Base.get_tessellated_idx_from_point(verts, t_verts, 400), 6)
-	assert_eq(SS2D_Shape_Base.get_tessellated_idx_from_point(verts, t_verts, -1), 0)
-	assert_eq(SS2D_Shape_Base.get_tessellated_idx_from_point(verts, t_verts, -100), 0)
+	assert_eq(SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, 0), 0)
+	assert_eq(SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, 1), 2)
+	assert_eq(SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, 2), 4)
+	assert_eq(SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, 3), 6)
+	assert_eq(SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, 400), 6)
+	assert_eq(SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, -1), 0)
+	assert_eq(SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, -100), 0)
 
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 0), 0)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 1), 0)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 2), 1)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 3), 1)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 4), 2)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 5), 2)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 6), 3)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, 600), 3)
-	assert_eq(SS2D_Shape_Base.get_vertex_idx_from_tessellated_point(verts, t_verts, -600), 0)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 0), 0)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 1), 0)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 2), 1)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 3), 1)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 4), 2)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 5), 2)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 6), 3)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, 600), 3)
+	assert_eq(SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, -600), 0)
 
 func test_get_meta_material_index_mapping_simple_squareish_shape():
 	var verts = [
@@ -72,7 +72,7 @@ func test_get_meta_material_index_mapping_simple_squareish_shape():
 		assert_not_null(edges)
 		assert_eq(1, edges.size())
 
-	var mappings = SS2D_Shape_Base.get_meta_material_index_mapping(shape_material, verts, false)
+	var mappings = SS2D_Shape.get_meta_material_index_mapping(shape_material, verts, false)
 	var mappings_materials = []
 	for mapping in mappings:
 		mappings_materials.push_back(mapping.object)
@@ -110,7 +110,7 @@ func test_get_meta_material_index_mapping_complex_shape():
 	]
 	# Create shape material with 4 quadrants of normal range
 	var shape_material = create_shape_material_with_equal_normal_ranges(4)
-	var mappings = SS2D_Shape_Base.get_meta_material_index_mapping(shape_material, verts, false)
+	var mappings = SS2D_Shape.get_meta_material_index_mapping(shape_material, verts, false)
 	var mappings_materials = []
 	for mapping in mappings:
 		mappings_materials.push_back(mapping.object)
@@ -144,13 +144,13 @@ func test_build_edge_with_material_basic_square(offset = use_parameters(offset_p
 	var tex = TEST_TEXTURE
 	var tex_size = tex.get_size()
 	var shape_material = create_shape_material_with_equal_normal_ranges(4, tex)
-	var shape = SS2D_Shape_Base.new()
+	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
 	shape._is_instantiable = true
 	shape.shape_material = shape_material
 	shape.set_point_array(point_array)
 
-	var index_maps = SS2D_Shape_Base.get_meta_material_index_mapping(shape_material, verts, false)
+	var index_maps = SS2D_Shape.get_meta_material_index_mapping(shape_material, verts, false)
 	var edges = []
 
 	assert_eq(index_maps.size(), 3)
@@ -185,7 +185,7 @@ func test_build_quad_no_texture(width: float = use_parameters(width_params)):
 	var custom_offset: float = 0.0
 	var custom_extends: float = 0.0
 	var fit_texture := SS2D_Material_Edge.FITMODE.SQUISH_AND_STRETCH
-	var q: SS2D_Quad = SS2D_Shape_Base.build_quad_from_two_points(
+	var q: SS2D_Quad = SS2D_Shape.build_quad_from_two_points(
 		pt, pt_next,
 		tex,
 		width,
@@ -216,7 +216,7 @@ func test_build_quad_with_texture(width_scale = use_parameters(width_params)):
 	var custom_offset: float = 0.0
 	var custom_extends: float = 0.0
 	var fit_texture := SS2D_Material_Edge.FITMODE.SQUISH_AND_STRETCH
-	var q = SS2D_Shape_Base.build_quad_from_two_points(
+	var q = SS2D_Shape.build_quad_from_two_points(
 		pt, pt_next,
 		tex,
 		width_scale * tex_height,
@@ -240,18 +240,18 @@ func test_should_edge_generate_corner():
 	var pt_prev: Vector2 = Vector2(-16, 00)
 	var pt: Vector2 =      Vector2(000, 00)
 	var pt_next: Vector2 = Vector2(000, 16)
-	var corner = SS2D_Shape_Base.edge_should_generate_corner(pt_prev, pt, pt_next, false)
+	var corner = SS2D_Shape.edge_should_generate_corner(pt_prev, pt, pt_next, false)
 	assert_eq(corner, SS2D_Quad.CORNER.OUTER)
-	corner = SS2D_Shape_Base.edge_should_generate_corner(pt_prev, pt, pt_next, true)
+	corner = SS2D_Shape.edge_should_generate_corner(pt_prev, pt, pt_next, true)
 	assert_eq(corner, SS2D_Quad.CORNER.INNER)
 
 	# V Shape
 	pt_prev = Vector2(-8, -8)
 	pt =      Vector2(00, 00)
 	pt_next = Vector2(-8, 08)
-	corner = SS2D_Shape_Base.edge_should_generate_corner(pt_prev, pt, pt_next, false)
+	corner = SS2D_Shape.edge_should_generate_corner(pt_prev, pt, pt_next, false)
 	assert_eq(corner, SS2D_Quad.CORNER.OUTER)
-	corner = SS2D_Shape_Base.edge_should_generate_corner(pt_prev, pt, pt_next, true)
+	corner = SS2D_Shape.edge_should_generate_corner(pt_prev, pt, pt_next, true)
 	assert_eq(corner, SS2D_Quad.CORNER.INNER)
 
 func test_build_corner_quad():
@@ -266,8 +266,8 @@ func test_build_corner_quad():
 	var custom_scale: float = 1.0
 	var custom_offset: float = 0.0
 
-	var corner_status = SS2D_Shape_Base.edge_should_generate_corner(pt_prev, pt, pt_next, flip_edges)
-	var q = SS2D_Shape_Base.build_quad_corner(
+	var corner_status = SS2D_Shape.edge_should_generate_corner(pt_prev, pt, pt_next, flip_edges)
+	var q = SS2D_Shape.build_quad_corner(
 		pt_next, pt, pt_prev,
 		width, width_prev,
 		flip_edges,
@@ -278,7 +278,7 @@ func test_build_corner_quad():
 	)
 	gut.p("Test custom_scale")
 	assert_quad_point_eq(gut,q, Vector2(-4,-4),Vector2(-4,4),Vector2(4,4),Vector2(4,-4),Vector2(0,0))
-	q = SS2D_Shape_Base.build_quad_corner(
+	q = SS2D_Shape.build_quad_corner(
 		pt_next, pt, pt_prev,
 		width, width_prev,
 		flip_edges,
@@ -290,7 +290,7 @@ func test_build_corner_quad():
 	assert_quad_point_eq(gut,q, Vector2(-8,-8),Vector2(-8,8),Vector2(8,8),Vector2(8,-8),Vector2(0,0))
 
 	gut.p("Test width")
-	q = SS2D_Shape_Base.build_quad_corner(
+	q = SS2D_Shape.build_quad_corner(
 		pt_next, pt, pt_prev,
 		width*2, width_prev,
 		flip_edges,
@@ -302,7 +302,7 @@ func test_build_corner_quad():
 	assert_quad_point_eq(gut,q, Vector2(-8,-4),Vector2(-8,4),Vector2(8,4),Vector2(8,-4),Vector2(0,0))
 
 	gut.p("Test width + custom_scale")
-	q = SS2D_Shape_Base.build_quad_corner(
+	q = SS2D_Shape.build_quad_corner(
 		pt_next, pt, pt_prev,
 		width*2, width_prev*2,
 		flip_edges,
@@ -313,7 +313,7 @@ func test_build_corner_quad():
 	)
 	assert_quad_point_eq(gut,q, Vector2(-16,-16),Vector2(-16,16),Vector2(16,16),Vector2(16,-16),Vector2(0,0))
 	gut.p("Test width_prev")
-	q = SS2D_Shape_Base.build_quad_corner(
+	q = SS2D_Shape.build_quad_corner(
 		pt_next, pt, pt_prev,
 		width, width_prev*2,
 		flip_edges,
@@ -327,7 +327,7 @@ func test_build_corner_quad():
 	gut.p("Test custom_offset")
 	gut.p("For this shape, shoud offset up and to the right (postivie x, negative y)")
 	custom_offset = 1.0
-	q = SS2D_Shape_Base.build_quad_corner(
+	q = SS2D_Shape.build_quad_corner(
 		pt_next, pt, pt_prev,
 		width, width_prev,
 		flip_edges,
@@ -352,7 +352,7 @@ func test_weld_quads():
 	var left = SS2D_Quad.new(Vector2(-4, -4), Vector2(-4, 4), Vector2(4, 4), Vector2(4, -4), null, false)
 	var right = SS2D_Quad.new(Vector2(-8, -8), Vector2(-8, 8), Vector2(8, 8), Vector2(8, -8), null, false)
 	var custom_scale:float=1.0
-	SS2D_Shape_Base.weld_quads(left, right, custom_scale)
+	SS2D_Shape.weld_quads(left, right, custom_scale)
 	var pt_top = (left.pt_d + right.pt_a)/2.0
 	var pt_bottom = (left.pt_c + right.pt_b)/2.0
 	assert_quad_point_eq(gut,left, left.pt_a, left.pt_b, pt_bottom, pt_top)

--- a/tests/unit/test_shape_open.gd
+++ b/tests/unit/test_shape_open.gd
@@ -12,7 +12,7 @@ class z_sort:
 
 func test_z_sort():
 	var a = [z_sort.new(3), z_sort.new(5), z_sort.new(0), z_sort.new(-12)]
-	a = SS2D_Shape_Open.sort_by_z_index(a)
+	a = SS2D_Shape.sort_by_z_index(a)
 	assert_eq(a[0].z_index, -12)
 	assert_eq(a[1].z_index, 0)
 	assert_eq(a[2].z_index, 3)
@@ -25,21 +25,21 @@ func test_on_segment():
 	var p3 = Vector2(100, 0)
 	var p4 = Vector2(100, 10)
 	var p5 = Vector2(100, 20)
-	assert_true(SS2D_Shape_Open.on_segment(p2, p1, p3))
-	assert_false(SS2D_Shape_Open.on_segment(p2, p3, p1))
-	assert_false(SS2D_Shape_Open.on_segment(p1, p2, p3))
-	assert_false(SS2D_Shape_Open.on_segment(p1, p3, p2))
-	assert_false(SS2D_Shape_Open.on_segment(p3, p2, p1))
-	assert_true(SS2D_Shape_Open.on_segment(p3, p1, p2))
+	assert_true(SS2D_Shape.on_segment(p2, p1, p3))
+	assert_false(SS2D_Shape.on_segment(p2, p3, p1))
+	assert_false(SS2D_Shape.on_segment(p1, p2, p3))
+	assert_false(SS2D_Shape.on_segment(p1, p3, p2))
+	assert_false(SS2D_Shape.on_segment(p3, p2, p1))
+	assert_true(SS2D_Shape.on_segment(p3, p1, p2))
 
-	assert_true(SS2D_Shape_Open.on_segment(p3, p4, p5))
-	assert_false(SS2D_Shape_Open.on_segment(p3, p5, p4))
+	assert_true(SS2D_Shape.on_segment(p3, p4, p5))
+	assert_false(SS2D_Shape.on_segment(p3, p5, p4))
 
-	assert_true(SS2D_Shape_Open.on_segment(p1, p1, p1))
+	assert_true(SS2D_Shape.on_segment(p1, p1, p1))
 
 
 func test_are_points_clockwise():
-	var shape = SS2D_Shape_Open.new()
+	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
 	var points_clockwise = [Vector2(-10, -10), Vector2(10, -10), Vector2(10, 10), Vector2(-10, 10)]
 	var points_c_clockwise = points_clockwise.duplicate()
@@ -54,7 +54,7 @@ func test_are_points_clockwise():
 
 
 func test_curve_duplicate():
-	var shape = SS2D_Shape_Open.new()
+	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
 	shape.add_point(Vector2(-10, -20))
 	var points = [Vector2(-10, -10), Vector2(10, -10), Vector2(10, 10), Vector2(-10, 10)]
@@ -73,7 +73,7 @@ func test_curve_duplicate():
 
 
 func test_tess_point_vertex_relationship():
-	var shape := SS2D_Shape_Open.new()
+	var shape := SS2D_Shape.new()
 	add_child_autofree(shape)
 	var points := get_clockwise_points()
 
@@ -94,10 +94,10 @@ func test_tess_point_vertex_relationship():
 	assert_ne(points.size(), t_verts.size())
 
 	var test_idx := 4
-	var test_t_idx := SS2D_Shape_Open.get_tessellated_idx_from_point(verts, t_verts, test_idx)
+	var test_t_idx := SS2D_Shape.get_tessellated_idx_from_point(verts, t_verts, test_idx)
 	assert_ne(test_idx, test_t_idx)
 	assert_eq(verts[test_idx], t_verts[test_t_idx])
-	var new_test_idx := SS2D_Shape_Open.get_vertex_idx_from_tessellated_point(verts, t_verts, test_t_idx)
+	var new_test_idx := SS2D_Shape.get_vertex_idx_from_tessellated_point(verts, t_verts, test_t_idx)
 	assert_eq(test_idx, new_test_idx)
 
 	var results := [
@@ -116,7 +116,7 @@ func test_tess_point_vertex_relationship():
 
 
 func test_invert_point_order():
-	var shape = SS2D_Shape_Open.new()
+	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
 	var points = get_clockwise_points()
 	var size = points.size()
@@ -178,7 +178,7 @@ func test_invert_point_order():
 
 
 func test_get_edge_meta_materials_one():
-	var shape = SS2D_Shape_Open.new()
+	var shape = SS2D_Shape.new()
 	assert_eq(shape.get_point_array().get_material_overrides().size(), 0)
 	add_child_autofree(shape)
 	assert_eq(shape.get_point_array().get_material_overrides().size(), 0)
@@ -203,7 +203,7 @@ func test_get_edge_meta_materials_one():
 	var points = get_clockwise_points()
 	shape.add_points(points)
 	assert_eq(shape.get_point_array().get_material_overrides().size(), 0)
-	var mappings = SS2D_Shape_Open.get_meta_material_index_mapping(s_m, points, false)
+	var mappings = SS2D_Shape.get_meta_material_index_mapping(s_m, points, false)
 
 	# Should be 1 edge, as the normal range specified covers the full 360.0 degrees
 	assert_eq(mappings.size(), 1, "Should be one EdgeData specified")
@@ -214,7 +214,7 @@ func test_get_edge_meta_materials_one():
 
 
 func test_get_edge_meta_materials_many():
-	var shape = SS2D_Shape_Open.new()
+	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
 	assert_eq(shape.get_point_array().get_material_overrides().size(), 0)
 
@@ -260,7 +260,7 @@ func test_get_edge_meta_materials_many():
 	assert_eq(shape.get_point_array().get_material_overrides().size(), 0)
 	assert_eq(shape.get_vertices().size(), 6)
 	assert_eq(s_m.get_all_edge_meta_materials().size(), edge_materials_meta.size())
-	var mappings = SS2D_Shape_Open.get_meta_material_index_mapping(s_m, points, false)
+	var mappings = SS2D_Shape.get_meta_material_index_mapping(s_m, points, false)
 	assert_eq(mappings.size(), edge_materials_count, "Expecting %s materials" % edge_materials_count)
 	var expected_indicies = [[0, 1, 2], [2, 3], [3, 4], [4, 5]]
 	for i in range(0, mappings.size(), 1):
@@ -272,7 +272,7 @@ var width_params = [1.0, 1.5, 0.5, 0.0, 10.0, -1.0]
 
 
 func test_build_quad_from_point_width(width = use_parameters(width_params)):
-	var shape = SS2D_Shape_Open.new()
+	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
 
 	var pt_prev = Vector2(100, 100)
@@ -288,7 +288,7 @@ func test_build_quad_from_point_width(width = use_parameters(width_params)):
 	var tex_size = TEST_TEXTURE.get_size()
 	var vtx: Vector2 = normal * (tex_size * 0.5)
 
-	var quad := SS2D_Shape_Open.build_quad_from_two_points(
+	var quad := SS2D_Shape.build_quad_from_two_points(
 		pt,
 		pt_next,
 		TEST_TEXTURE,
@@ -311,7 +311,7 @@ func test_build_quad_from_point_width(width = use_parameters(width_params)):
 
 
 func test_get_width_for_tessellated_point():
-	var shape = SS2D_Shape_Open.new()
+	var shape = SS2D_Shape.new()
 	add_child_autofree(shape)
 	var points = get_clockwise_points()
 	shape.add_points(points)
@@ -333,8 +333,8 @@ func test_get_width_for_tessellated_point():
 
 	var t_points = shape.get_tessellated_points()
 	points = shape.get_vertices()
-	var t_idx_1 = SS2D_Shape_Open.get_tessellated_idx_from_point(points, t_points, idx1)
-	var t_idx_2 = SS2D_Shape_Open.get_tessellated_idx_from_point(points, t_points, idx2)
+	var t_idx_1 = SS2D_Shape.get_tessellated_idx_from_point(points, t_points, idx1)
+	var t_idx_2 = SS2D_Shape.get_tessellated_idx_from_point(points, t_points, idx2)
 	var test_t_idx = int(floor((t_idx_1 + t_idx_2) / 2.0))
 	assert_ne(t_idx_1, t_idx_2)
 	assert_ne(test_t_idx, t_idx_1)


### PR DESCRIPTION
This PR aims to improve user experience when creating shapes as discussed in #117 and #101.

The `SS2D_Shape` node combines the functionality of open and closed shapes. A shape can be closed at any time by adding a point on top of the first point. Additionally, the new Cut Edge tool allows for opening shapes and can also split a shape into two smaller shapes (#101). Furthermore, the update includes the ability to create points with Bezier curves directly while adding them. The added functionality is fully compatible with the editor's undo-redo system.

![cut-tool](https://github.com/SirRamEsq/SmartShape2D/assets/2766569/20707c1c-3bfd-45ff-9458-10ba6266f076)

`SS2D_Shape_Open` and `SS2D_Shape_Closed` are marked as deprecated and inherit from `SS2D_Shape`. These
classes are empty now and do not provide any additional functionality. They are needed for backwards compatibility. However, they can be removed in a future revision if deemed unnecessary. Certain unused methods are left commented out in case they are still needed for something.

All tests pass, and new tests have been added. The unit tests that verify closed shape functionality needed to be updated to accommodate changes in how closed shapes are handled.

#### Testing

While under review, my PRs (#118, #123 and #126) are available merged in this branch: https://github.com/limbonaut/SmartShape2D/tree/integration

