### PR TITLE
Fix Godot 4.1 errors

### DIFF
--- a/addons/rmsmartshape/editors/action_property_inspector_plugin.gd
+++ b/addons/rmsmartshape/editors/action_property_inspector_plugin.gd
@@ -44,7 +44,7 @@ func _parse_property(
 	name: String,
 	_hint_type: PropertyHint,
 	hint_string: String,
-	_usage_flags: PropertyUsageFlags,
+	_usage_flags,
 	_wide: bool
 ) -> bool:
 	if hint_string == "ActionProperty":

--- a/addons/rmsmartshape/editors/normal_range_inspector_plugin.gd
+++ b/addons/rmsmartshape/editors/normal_range_inspector_plugin.gd
@@ -35,7 +35,7 @@ func _parse_property(
 	name: String,
 	_hint_type: PropertyHint,
 	_hint_string: String,
-	_usage_flags: PropertyUsageFlags,
+	_usage_flags,
 	_wide: bool
 ) -> bool:
 	if name == "edgeRendering":

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -365,6 +365,7 @@ func _ready() -> void:
 	make_unique_dialog.get_label().text = "Make shape point geometry unique (not materials). Proceed?"
 	make_unique_dialog.get_ok_button().text = "Proceed"
 	make_unique_dialog.add_cancel_button("Cancel")
+	make_unique_dialog.theme = get_editor_interface().get_base_control().theme
 	make_unique_dialog.connect("confirmed", self._shape_make_unique)
 	add_child(make_unique_dialog)
 

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="SmartShape2D"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
 
 [editor_plugins]


### PR DESCRIPTION
Fixes issues with `_parse_property` signature in Godot 4.1 while preserving backwards compatibility.
Also fixes lack of theming in "Make Unique" dialog.

<details>
<summary>Error messages that this PR fixes</summary>

```
res://addons/rmsmartshape/editors/action_property_inspector_plugin.gd:41 - Parse Error: The function signature doesn't match the parent. Parent signature is "_parse_property(Object, Variant.Type, String, PropertyHint, String, int, bool) -> bool".
res://addons/rmsmartshape/editors/normal_range_inspector_plugin.gd:32 - Parse Error: The function signature doesn't match the parent. Parent signature is "_parse_property(Object, Variant.Type, String, PropertyHint, String, int, bool) -> bool".
```

</details>

#### Testing

While under review, my PRs (#118, #123 and #126) are available merged in this branch: https://github.com/limbonaut/SmartShape2D/tree/integration
