### PR TITLE
Added documentation for fill_texture_z_index

### DIFF
--- a/addons/rmsmartshape/documentation/Shapes.md
+++ b/addons/rmsmartshape/documentation/Shapes.md
@@ -48,6 +48,7 @@ There are three kinds of shapes:
 - Is Autoset when pressing the generate collision button.
 ## Shape Material
 - The material that this shape will use to render itself.
+- For backwards compatibility `fill_texture_z_index` defaults to `-10`. Set this to `0` and enable `fill_texture_show_behind_parent` in order to preserve Godot's normal z-sorting when layering with other nodes.
 ## Points
 - **There is no need to edit this property by hand, but you can if you'd like.**
 - Contains all of the points and meta-data for the points contained in this shape.


### PR DESCRIPTION
Currently `fill_texture_z_index` defaults to `-10` which can be confusing (it was to me) to new users when layering with other Godot nodes as the z-sorting appears random at first.
This PR adds information why the behaviour is there and how to deal with it.