### PR TITLE
Improved editing for transformed shapes

### DIFF
--- a/addons/rmsmartshape/actions/action_set_pivot.gd
+++ b/addons/rmsmartshape/actions/action_set_pivot.gd
@@ -34,7 +34,7 @@ func undo() -> void:
 
 
 func _set_pivot(shape_position: Vector2, parent_body_position: Vector2) -> void:
-	var xform: Transform2D = _shape.get_global_transform()
+	var shape_gt: Transform2D = _shape.get_global_transform()
 	
 	if _shape.get_parent() == _parent_body:
 		_parent_body.global_position = parent_body_position
@@ -46,7 +46,7 @@ func _set_pivot(shape_position: Vector2, parent_body_position: Vector2) -> void:
 	for i in _shape.get_point_count():
 		var key: int = _shape.get_point_key_at_index(i)
 		var point: Vector2 = _shape.get_point_position(key)
-		_shape.set_point_position(key, _shape.to_local(xform * point))
+		_shape.set_point_position(key, _shape.to_local(shape_gt * point))
 		
 	_shape.enable_constraints()
 	_shape.end_update()

--- a/addons/rmsmartshape/actions/action_set_pivot.gd
+++ b/addons/rmsmartshape/actions/action_set_pivot.gd
@@ -5,20 +5,14 @@ extends SS2D_Action
 var _shape: SS2D_Shape
 var _parent_body: PhysicsBody2D
 
-var _old_shape_pos: Vector2
-var _old_body_pos: Vector2
-
 var _new_pos: Vector2
+var _old_pos: Vector2
 
 
 func _init(s: SS2D_Shape, pos: Vector2) -> void:
 	_shape = s
 	_new_pos = pos
-	_old_shape_pos = _shape.global_position
-	var parent = _shape.get_parent()
-	if parent is PhysicsBody2D:
-		_parent_body = parent
-		_old_body_pos = parent.global_position
+	_old_pos = _shape.global_position
 
 
 func get_name() -> String:
@@ -26,18 +20,16 @@ func get_name() -> String:
 
 
 func do() -> void:
-	_set_pivot(_new_pos, _new_pos)
+	_set_pivot(_new_pos)
 
 
 func undo() -> void:
-	_set_pivot(_old_shape_pos, _old_body_pos)
+	_set_pivot(_old_pos)
 
 
-func _set_pivot(shape_position: Vector2, parent_body_position: Vector2) -> void:
+func _set_pivot(shape_position: Vector2) -> void:
 	var shape_gt: Transform2D = _shape.get_global_transform()
-	
-	if _shape.get_parent() == _parent_body:
-		_parent_body.global_position = parent_body_position
+
 	_shape.global_position = shape_position
 
 	_shape.begin_update()

--- a/addons/rmsmartshape/actions/action_set_pivot.gd
+++ b/addons/rmsmartshape/actions/action_set_pivot.gd
@@ -3,14 +3,22 @@ extends SS2D_Action
 ## ActionSetPivot
 
 var _shape: SS2D_Shape
-var _old_pos: Vector2
+var _parent_body: PhysicsBody2D
+
+var _old_shape_pos: Vector2
+var _old_body_pos: Vector2
+
 var _new_pos: Vector2
 
 
-func _init(s: SS2D_Shape, et: Transform2D, pos: Vector2) -> void:
+func _init(s: SS2D_Shape, pos: Vector2) -> void:
 	_shape = s
 	_new_pos = pos
-	_old_pos = et * s.get_parent().get_global_transform() * s.position
+	_old_shape_pos = _shape.global_position
+	var parent = _shape.get_parent()
+	if parent is PhysicsBody2D:
+		_parent_body = parent
+		_old_body_pos = parent.global_position
 
 
 func get_name() -> String:
@@ -18,25 +26,28 @@ func get_name() -> String:
 
 
 func do() -> void:
-	_set_pivot(_new_pos)
+	_set_pivot(_new_pos, _new_pos)
 
 
 func undo() -> void:
-	_set_pivot(_old_pos)
+	_set_pivot(_old_shape_pos, _old_body_pos)
 
 
-func _set_pivot(point: Vector2) -> void:
-	var np: Vector2 = point
-	var ct: Transform2D = _shape.get_global_transform()
-	ct.origin = np
-	var xform := ct.affine_inverse() * _shape.get_global_transform()
+func _set_pivot(shape_position: Vector2, parent_body_position: Vector2) -> void:
+	var xform: Transform2D = _shape.get_global_transform()
+	
+	if _shape.get_parent() == _parent_body:
+		_parent_body.global_position = parent_body_position
+	_shape.global_position = shape_position
 
 	_shape.begin_update()
 	_shape.disable_constraints()
+
 	for i in _shape.get_point_count():
 		var key: int = _shape.get_point_key_at_index(i)
-		_shape.set_point_position(key, xform * _shape.get_point_position(key))
+		var point: Vector2 = _shape.get_point_position(key)
+		_shape.set_point_position(key, _shape.to_local(xform * point))
+		
 	_shape.enable_constraints()
 	_shape.end_update()
 
-	_shape.position = _shape.get_parent().get_global_transform().affine_inverse() * np

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -1458,11 +1458,15 @@ func _input_motion_move_control_points(delta: Vector2, _in: bool, _out: bool) ->
 		# Invert the delta for position_out if moving both at once
 		if _out and _in:
 			out_multiplier = -1
+
 		var new_position_in: Vector2 = delta + current_action.starting_positions_control_in[i]
-		var new_position_out: Vector2 = (
+		
+		var from_out: Vector2 = shape.to_global(current_action.starting_positions_control_out[i])
+		var new_position_out: Vector2 = shape.global_transform.affine_inverse() * (
 			(delta * out_multiplier)
-			+ current_action.starting_positions_control_out[i]
+			+ from_out
 		)
+
 		if use_snap():
 			new_position_in = snap(new_position_in)
 			new_position_out = snap(new_position_out)
@@ -1480,8 +1484,8 @@ func _input_motion_move_control_points(delta: Vector2, _in: bool, _out: bool) ->
 func _input_motion_move_verts(delta: Vector2) -> bool:
 	for i in range(0, current_action.keys.size(), 1):
 		var key: int = current_action.keys[i]
-		var from: Vector2 = current_action.starting_positions[i]
-		var new_position: Vector2 = from + delta
+		var from: Vector2 = shape.to_global(current_action.starting_positions[i])
+		var new_position: Vector2 = shape.global_transform.affine_inverse() * (from + delta)
 		if use_snap():
 			new_position = snap(new_position)
 		shape.set_point_position(key, new_position)

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -265,8 +265,6 @@ func _gui_build_toolbar() -> void:
 	tb_hb.add_child(tb_options)
 	tb_options_popup.connect("id_pressed", self._options_item_selected)
 
-	tb_hb.hide()
-
 
 func create_tool_button(icon: Texture2D, tooltip: String, toggle: bool = true) -> Button:
 	var tb := Button.new()
@@ -493,7 +491,7 @@ func _handles(object: Object) -> bool:
 		if selection.get_selected_nodes().size() == 1:
 			if selection.get_selected_nodes()[0] is SS2D_Shape:
 				hideToolbar = false
-
+				
 	if hideToolbar == true:
 		tb_hb.hide()
 
@@ -511,8 +509,6 @@ func _edit(object: Object) -> void:
 
 	shape = null
 
-	tb_hb.show()
-
 	shape = object
 
 	if not is_shape_valid(shape):
@@ -526,7 +522,8 @@ func _edit(object: Object) -> void:
 
 
 func _make_visible(_visible: bool) -> void:
-	pass
+	if _visible:
+		tb_hb.show()
 
 
 func _on_main_screen_changed(screen_name: String) -> void:
@@ -759,7 +756,7 @@ func _center_pivot() -> void:
 		if total_area != 0.0:
 			center /= 3 * total_area
 
-		perform_action(ActionSetPivot.new(shape, Transform2D.IDENTITY, shape.to_global(center)))
+		perform_action(ActionSetPivot.new(shape, shape.to_global(center)))
 
 #############
 # RENDERING #
@@ -1087,7 +1084,7 @@ func _input_handle_left_click(
 		var local_position: Vector2 = et.affine_inverse() * mb.position
 		if use_snap():
 			local_position = snap(local_position)
-		perform_action(ActionSetPivot.new(shape, et, local_position))
+		perform_action(ActionSetPivot.new(shape, local_position))
 		return true
 
 	if current_mode == MODE.EDIT_VERT or current_mode == MODE.CREATE_VERT:

--- a/tests/unit/test_plugin_actions.gd
+++ b/tests/unit/test_plugin_actions.gd
@@ -249,7 +249,7 @@ func test_action_set_pivot() -> void:
 	var key := s.add_point(Vector2.ZERO)
 
 	var t := Transform2D()
-	var action := ActionSetPivot.new(s, t, Vector2(100.0, 100.0))
+	var action := ActionSetPivot.new(s, Vector2(100.0, 100.0))
 	action.do()
 	assert_eq(s.get_point_position(key), Vector2(-100.0, -100.0))
 	action.undo()


### PR DESCRIPTION
- Adjusted mouse delta while editing vertices and control points on shapes where global_transform != identity
- "Set Pivot" action now works as expected on shapes where global_transform != identity
- Fixed a small issue where the editor buttons do not disappear after a shape is deselected
- Test change: `ActionSetPivot` action no longer takes a Transform2D argument

![2b8ed79420edede47fffbfbf9578a445](https://github.com/SirRamEsq/SmartShape2D/assets/47232037/b526458a-aeed-424f-98c3-867c241fe35a)
