### PR TITLE
Additional fill texture options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vscode/
 .import/
 .godot/

--- a/addons/rmsmartshape/materials/shape_material.gd
+++ b/addons/rmsmartshape/materials/shape_material.gd
@@ -11,6 +11,22 @@ class_name SS2D_Material_Shape
 @export var fill_textures: Array[Texture2D] = [] : set = set_fill_textures
 @export var fill_texture_z_index: int = -10 : set = set_fill_texture_z_index
 @export var fill_texture_show_behind_parent: bool = false : set = set_fill_texture_show_behind_parent
+
+## Scale the fill texture
+@export_range(0.1, 4, 0.01, "or_greater") var fill_texture_scale: float = 1.0 : set = set_fill_texture_scale
+
+## Whether the fill texture should start at the global 0/0 instead of the node's 0/0
+@export var fill_texture_absolute_position: bool = false : set = set_fill_texture_absolute_position
+
+## Whether the fill texture should ignore the node's rotation
+@export var fill_texture_absolute_rotation: bool = false : set = set_fill_texture_absolute_rotation
+
+## How many pixels the fill texture should be shifted in x and y direction
+@export var fill_texture_offset: Vector2 = Vector2.ZERO : set = set_fill_texture_offset
+
+## Added rotation of the texture in degrees
+@export_range(-180, 180, 0.1) var fill_texture_angle_offset: float = 0.0 : set = set_fill_texture_angle_offset
+
 @export var fill_mesh_offset: float = 0.0 : set = set_fill_mesh_offset
 @export var fill_mesh_material: Material = null : set = set_fill_mesh_material
 
@@ -95,4 +111,29 @@ func set_edge_meta_materials(a: Array[SS2D_Material_Edge_Metadata]) -> void:
 			e.connect("changed", self._on_edge_material_changed)
 
 	_edge_meta_materials = a
+	emit_changed()
+
+
+func set_fill_texture_offset(value: Vector2) -> void:
+	fill_texture_offset = value
+	emit_changed()
+
+
+func set_fill_texture_scale(value:float) -> void:
+	fill_texture_scale = value
+	emit_changed()
+
+
+func set_fill_texture_absolute_rotation(value: bool) -> void:
+	fill_texture_absolute_rotation = value
+	emit_changed()
+
+
+func set_fill_texture_angle_offset(value: float) -> void:
+	fill_texture_angle_offset = value
+	emit_changed()
+
+
+func set_fill_texture_absolute_position(value: bool) -> void:
+	fill_texture_absolute_position = value
 	emit_changed()

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -916,13 +916,13 @@ func _build_fill_mesh(points: PackedVector2Array, s_mat: SS2D_Material_Shape) ->
 
 	for i in range(0, fill_tris.size() - 1, 3):
 		st.set_color(Color.WHITE)
-		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(points[fill_tris[i]], tex_size))
+		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(_transform_point_for_uv(points[fill_tris[i]], s_mat), tex_size))
 		st.add_vertex(Vector3(points[fill_tris[i]].x, points[fill_tris[i]].y, 0))
 		st.set_color(Color.WHITE)
-		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(points[fill_tris[i + 1]], tex_size))
+		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(_transform_point_for_uv(points[fill_tris[i + 1]], s_mat), tex_size))
 		st.add_vertex(Vector3(points[fill_tris[i + 1]].x, points[fill_tris[i + 1]].y, 0))
 		st.set_color(Color.WHITE)
-		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(points[fill_tris[i + 2]], tex_size))
+		_add_uv_to_surface_tool(st, _convert_local_space_to_uv(_transform_point_for_uv(points[fill_tris[i + 2]], s_mat), tex_size))
 		st.add_vertex(Vector3(points[fill_tris[i + 2]].x, points[fill_tris[i + 2]].y, 0))
 	st.index()
 	st.generate_normals()
@@ -938,6 +938,27 @@ func _build_fill_mesh(points: PackedVector2Array, s_mat: SS2D_Material_Shape) ->
 	meshes.push_back(mesh_data)
 
 	return meshes
+
+
+func _transform_point_for_uv(point:Vector2, s_material: SS2D_Material_Shape) -> Vector2:
+	var new_point := point
+
+	# If absolute position ... cancel out the node's position (adjusted due to rotation)
+	if s_material.fill_texture_absolute_position:
+		new_point += global_position.rotated(-global_rotation)
+
+	# Scale
+	new_point /= s_material.fill_texture_scale
+
+	# If absolute rotation ... cancel out the node's rotation
+	if s_material.fill_texture_absolute_rotation: 
+		new_point = new_point.rotated(global_rotation)
+	
+	# Rotate and shift the desired extra amount
+	new_point = new_point.rotated(-deg_to_rad(s_material.fill_texture_angle_offset))
+	new_point -= s_material.fill_texture_offset
+
+	return new_point
 
 
 func _convert_local_space_to_uv(point: Vector2, size: Vector2) -> Vector2:

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -670,6 +670,11 @@ func _enter_tree() -> void:
 	# Call this again because get_node() only works when the node is inside the tree
 	set_collision_polygon_node_path(collision_polygon_node_path)
 
+	# Handle material changes if scene is (re-)entered (e.g. after switching to another)
+	if shape_material != null:
+		if not shape_material.is_connected("changed", self._handle_material_change):
+			shape_material.connect("changed", self._handle_material_change)
+
 
 func _get_rendering_nodes_parent() -> SS2D_Shape_Render:
 	var render_parent_name := "_SS2D_RENDER"

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -953,10 +953,12 @@ func _transform_point_for_uv(point:Vector2, s_material: SS2D_Material_Shape) -> 
 	# If absolute rotation ... cancel out the node's rotation
 	if s_material.fill_texture_absolute_rotation: 
 		new_point = new_point.rotated(global_rotation)
-	
-	# Rotate and shift the desired extra amount
+
+	# Rotate the desired extra amount
 	new_point = new_point.rotated(-deg_to_rad(s_material.fill_texture_angle_offset))
-	new_point -= s_material.fill_texture_offset
+
+	# Shift the desired amount (adjusted so it's scale independent)
+	new_point -= s_material.fill_texture_offset / s_material.fill_texture_scale
 
 	return new_point
 

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -923,7 +923,7 @@ func _build_fill_mesh(points: PackedVector2Array, s_mat: SS2D_Material_Shape) ->
 
 	for i in range(0, fill_tris.size() - 1, 3):
 		st.set_color(Color.WHITE)
-		_add_uv_to_surface_tool(st, uv_points[fill_tris[i + 0]])
+		_add_uv_to_surface_tool(st, uv_points[fill_tris[i]])
 		st.add_vertex(Vector3(points[fill_tris[i]].x, points[fill_tris[i]].y, 0))
 		st.set_color(Color.WHITE)
 		_add_uv_to_surface_tool(st, uv_points[fill_tris[i + 1]])


### PR DESCRIPTION
### This PR introduces the additional settings for a ShapeMaterial's fill texture:
- **Scaling:** Useful when working with non-pixelart based assets
- **Global alignment** (position and rotation): Useful when shapes should overlap and the tiling should continue seamlessly
- **Offsets** (position and rotation): Works _without_ global alignments but especially handy there for fine-tuning
- (And: Added Mac .DS_Store files to gitignore)

### Usage

https://github.com/SirRamEsq/SmartShape2D/assets/7897006/d65feeea-adea-4bf4-9206-2d18cc658b66

### Tests
I ran the GUT-tests successfully. But I have never written tests in Godot so I didn't add new ones.

<details>
<summary>Show log</summary>


```
res://tests/unit/test_tuple.gd.
* test_equality
* test_find
* test_get_other_value
* test_is_tuple
23/23 passed.

==============================================
= Run Summary
==============================================
All tests passed

Totals
Scripts:          14
Passing tests     65
Failing tests     0
Risky tests       0
Pending:          0
Asserts:          1103 of 1103 passed

65 passed 0 failed.  Tests finished in 1.102s
```

</details>

### Note
As this is my first (proper) PR with some bigger changes it would be great if some people could test it in their projects ❤️

PS: SmartShape is great 🚀