### PR TITLE
Only include the "addons/rmsmartshape" when downloading from the Asset Library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Normalize line endings for all files that Git considers text files.
+* text=auto eol=lf
+
+# Only include the addons/rmsmartshape folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/rmsmartshape	!export-ignore
+/addons/rmsmartshape/** !export-ignore
+/README.md !export-ignore
+/LICENSE !export-ignore

--- a/README.md
+++ b/README.md
@@ -29,14 +29,8 @@ Read the section below on Contributing and post an issue if one doesn't already 
 
 ## Support
 
-- Newest version is developed for Godot 4
-- Older version is supported and tested on Godot 3.2
-  - Should work with later versions of Godot 3.x
-
-## Demo
-
-A Sample Godot Project can be found here:
-https://github.com/SirRamEsq/SmartShape2D-DemoProject
+- Newest version is developed and supported for Godot 4.x
+- For Godot 3.x version, please go [here](https://github.com/SirRamEsq/SmartShape2D/tree/Godot3-latest)
 
 ## Documentation
 > 🛈 Some documentation is outdated.


### PR DESCRIPTION
Also, small README fix.