### PR TITLE
Fix child CollisionPolygon being transformed twice

### DIFF
--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -843,8 +843,14 @@ func generate_collision_points() -> PackedVector2Array:
 func bake_collision() -> void:
 	if not _collision_polygon_node:
 		return
-	var xform := _collision_polygon_node.get_global_transform().inverse() * get_global_transform()
-	_collision_polygon_node.polygon = xform * generate_collision_points()
+
+	var collision_points := generate_collision_points()
+
+	# Collision polygon is a child node -> don't apply transform
+	if str(_collision_polygon_node.get_path()).begins_with(str(get_path())):
+		_collision_polygon_node.polygon = collision_points
+	else:
+		_collision_polygon_node.polygon = get_global_transform() * collision_points
 
 
 func cache_edges() -> void:
@@ -947,8 +953,8 @@ func _build_fill_mesh(points: PackedVector2Array, s_mat: SS2D_Material_Shape) ->
 
 
 func _get_uv_points(
-	points: PackedVector2Array, 
-	s_material: SS2D_Material_Shape, 
+	points: PackedVector2Array,
+	s_material: SS2D_Material_Shape,
 	tex_size: Vector2
 ) -> PackedVector2Array:
 	var transformation: Transform2D = global_transform
@@ -962,7 +968,7 @@ func _get_uv_points(
 	transformation = transformation.scaled(Vector2(tex_scale, tex_scale))
 
 	# If relative rotation ... undo rotation from global_transform
-	if not s_material.fill_texture_absolute_rotation: 
+	if not s_material.fill_texture_absolute_rotation:
 		transformation = transformation.rotated(-global_rotation)
 
 	# Rotate the desired extra amount
@@ -970,10 +976,10 @@ func _get_uv_points(
 
 	# Shift the desired amount (adjusted so it's scale independent)
 	transformation = transformation.translated(-s_material.fill_texture_offset / s_material.fill_texture_scale)
-	
+
 	# Convert local space to UV
 	transformation = transformation.scaled(Vector2(1 / tex_size.x, 1 / tex_size.y))
-	
+
 	return transformation * points
 
 


### PR DESCRIPTION
Fixes #141

Also includes some lines where trailing spaces have been removed automatically.