### PR TITLE
Remove unnecessary transforms when baking collision polygon

### DIFF
--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -843,8 +843,7 @@ func generate_collision_points() -> PackedVector2Array:
 func bake_collision() -> void:
 	if not _collision_polygon_node:
 		return
-	var xform := _collision_polygon_node.get_global_transform().inverse() * get_global_transform()
-	_collision_polygon_node.polygon = xform * generate_collision_points()
+	_collision_polygon_node.polygon = generate_collision_points()
 
 
 func cache_edges() -> void:


### PR DESCRIPTION
Closes #141 

I'm not sure what was originally the purpose of the transforms, but with the scene tree structure generated by the addon when clicking the Collision Tool button, it seems to have the correct behaviour without any extra application of transforms.

The auto-generated scene tree structure:
![image](https://github.com/SirRamEsq/SmartShape2D/assets/41743877/383f28c9-f58f-4189-a0ed-234acc653ff9)
