### PR TITLE
Use correct inverse when applying transform of SS2D shape on collision polygon

### DIFF
--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -843,7 +843,7 @@ func generate_collision_points() -> PackedVector2Array:
 func bake_collision() -> void:
 	if not _collision_polygon_node:
 		return
-	var xform := _collision_polygon_node.get_global_transform().inverse() * get_global_transform()
+	var xform := _collision_polygon_node.get_global_transform().affine_inverse() * get_global_transform()
 	_collision_polygon_node.polygon = xform * generate_collision_points()
 
 


### PR DESCRIPTION
Closes #141 
Apparently the problem was simply that the wrong inverse method was being used. `inverse()` instead of `affine_inverse()`.

[As per the documentation](https://docs.godotengine.org/en/stable/classes/class_transform2d.html#class-transform2d-method-inverse):

> [Transform2D](https://docs.godotengine.org/en/stable/classes/class_transform2d.html#class-transform2d) inverse ( ) const
Returns the inverse of the transform, under the assumption that the transformation basis is orthonormal (i.e. rotation/reflection is fine, scaling/skew is not). Use [affine_inverse](https://docs.godotengine.org/en/stable/classes/class_transform2d.html#class-transform2d-method-affine-inverse) for non-orthonormal transforms (e.g. with scaling).

With this, the transform of the polygon itself is ignored, and only the transform of the SS2D shape matters.