### PR TITLE
Fix create tool alt mode not working

### DIFF
--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -1147,7 +1147,7 @@ func _input_handle_left_click(
 			elif Input.is_key_pressed(KEY_ALT):
 				# Add point between start and end points of the closest edge
 				idx = shape.get_point_index(closest_edge_keys[1])
-			var add_point := ActionAddPoint.new(shape, local_position, -1, not _defer_mesh_updates)
+			var add_point := ActionAddPoint.new(shape, local_position, idx, not _defer_mesh_updates)
 			perform_action(add_point)
 			if Input.is_key_pressed(KEY_SHIFT) and not Input.is_key_pressed(KEY_ALT):
 				select_control_points_to_move([add_point.get_key()], vp_m_pos)

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -947,8 +947,8 @@ func _build_fill_mesh(points: PackedVector2Array, s_mat: SS2D_Material_Shape) ->
 
 
 func _get_uv_points(
-	points: PackedVector2Array, 
-	s_material: SS2D_Material_Shape, 
+	points: PackedVector2Array,
+	s_material: SS2D_Material_Shape,
 	tex_size: Vector2
 ) -> PackedVector2Array:
 	var transformation: Transform2D = global_transform
@@ -962,7 +962,7 @@ func _get_uv_points(
 	transformation = transformation.scaled(Vector2(tex_scale, tex_scale))
 
 	# If relative rotation ... undo rotation from global_transform
-	if not s_material.fill_texture_absolute_rotation: 
+	if not s_material.fill_texture_absolute_rotation:
 		transformation = transformation.rotated(-global_rotation)
 
 	# Rotate the desired extra amount
@@ -970,10 +970,10 @@ func _get_uv_points(
 
 	# Shift the desired amount (adjusted so it's scale independent)
 	transformation = transformation.translated(-s_material.fill_texture_offset / s_material.fill_texture_scale)
-	
+
 	# Convert local space to UV
 	transformation = transformation.scaled(Vector2(1 / tex_size.x, 1 / tex_size.y))
-	
+
 	return transformation * points
 
 


### PR DESCRIPTION
When using create tool and holding ALT key, points should be inserted at the closest edge.

Spotted by @mphe, and reported on Discord.
