### PR TITLE
Refactor index-tuple implementation

### DIFF
--- a/addons/rmsmartshape/actions/action_delete_point.gd
+++ b/addons/rmsmartshape/actions/action_delete_point.gd
@@ -4,7 +4,7 @@ extends "res://addons/rmsmartshape/actions/action_delete_points.gd"
 
 
 func _init(shape: SS2D_Shape, key: int, commit_update: bool = true) -> void:
-	var keys: PackedInt64Array = [key]
+	var keys: PackedInt32Array = [key]
 	super(shape, keys, commit_update)
 
 

--- a/addons/rmsmartshape/actions/action_delete_points.gd
+++ b/addons/rmsmartshape/actions/action_delete_points.gd
@@ -67,21 +67,22 @@ func undo() -> void:
 		_shape.set_point_properties(_keys[i], _properties[i])
 	# Restore point constraints.
 	for i in range(_keys.size()-1, -1, -1):
-		for tuple: Array[int] in _constraints[i]:
+		for tuple: Vector2i in _constraints[i]:
 			_shape.set_constraint(tuple[0], tuple[1], _constraints[i][tuple])
 	_shape.end_update()
 
 
 func add_point_to_delete(key: int) -> void:
 	_keys.push_back(key)
-	var constraints: Dictionary = _shape.get_point_constraints(key)
+	var constraints := _shape.get_point_array().get_point_constraints(key)
 	# Save point constraints.
-	_constraints.append(_shape.get_point_constraints(key))
-	for tuple: Array[int] in constraints:
+	_constraints.append(constraints)
+
+	for tuple: Vector2i in constraints:
 		var constraint: SS2D_Point_Array.CONSTRAINT = constraints[tuple]
 		if constraint == SS2D_Point_Array.CONSTRAINT.NONE:
 			continue
-		var key_other: int = TUP.get_other_value_from_tuple(tuple, key)
+		var key_other := SS2D_IndexTuple.get_other_value(tuple, key)
 		if constraint & SS2D_Point_Array.CONSTRAINT.ALL:
 			if not _keys.has(key_other):
 				add_point_to_delete(key_other)

--- a/addons/rmsmartshape/actions/action_delete_points.gd
+++ b/addons/rmsmartshape/actions/action_delete_points.gd
@@ -11,8 +11,8 @@ const ActionCloseShape := preload("res://addons/rmsmartshape/actions/action_clos
 var _close_shape: ActionCloseShape
 
 var _shape: SS2D_Shape
-var _keys: PackedInt64Array
-var _indicies: PackedInt64Array
+var _keys: PackedInt32Array
+var _indicies: PackedInt32Array
 var _positions: PackedVector2Array
 var _points_in: PackedVector2Array
 var _points_out: PackedVector2Array
@@ -22,7 +22,7 @@ var _was_closed: bool
 var _commit_update: bool
 
 
-func _init(shape: SS2D_Shape, keys: PackedInt64Array, commit_update: bool = true) -> void:
+func _init(shape: SS2D_Shape, keys: PackedInt32Array, commit_update: bool = true) -> void:
 	_shape = shape
 	_invert_orientation = ActionInvertOrientation.new(shape)
 	_close_shape = ActionCloseShape.new(shape)

--- a/addons/rmsmartshape/actions/action_move_control_points.gd
+++ b/addons/rmsmartshape/actions/action_move_control_points.gd
@@ -3,14 +3,14 @@ extends SS2D_Action
 ## ActionMoveControlPoints
 
 var _shape: SS2D_Shape
-var _keys: PackedInt64Array
+var _keys: PackedInt32Array
 var _old_points_in: PackedVector2Array
 var _old_points_out: PackedVector2Array
 var _new_points_in: PackedVector2Array
 var _new_points_out: PackedVector2Array
 
 
-func _init(s: SS2D_Shape, keys: PackedInt64Array,
+func _init(s: SS2D_Shape, keys: PackedInt32Array,
 		old_points_in: PackedVector2Array, old_points_out: PackedVector2Array) -> void:
 	_shape = s
 	_keys = keys
@@ -33,7 +33,7 @@ func undo() -> void:
 	_assign_points_in_out(_keys, _old_points_in, _old_points_out)
 
 
-func _assign_points_in_out(keys: PackedInt64Array, in_positions: PackedVector2Array, out_positions: PackedVector2Array) -> void:
+func _assign_points_in_out(keys: PackedInt32Array, in_positions: PackedVector2Array, out_positions: PackedVector2Array) -> void:
 	_shape.begin_update()
 	for i in keys.size():
 		if _shape.get_point_in(keys[i]) != in_positions[i]:

--- a/addons/rmsmartshape/actions/action_move_verticies.gd
+++ b/addons/rmsmartshape/actions/action_move_verticies.gd
@@ -6,12 +6,12 @@ const ActionInvertOrientation := preload("res://addons/rmsmartshape/actions/acti
 var _invert_orientation: ActionInvertOrientation
 
 var _shape: SS2D_Shape
-var _keys: PackedInt64Array
+var _keys: PackedInt32Array
 var _old_positions: PackedVector2Array
 var _new_positions: PackedVector2Array
 
 
-func _init(s: SS2D_Shape, keys: PackedInt64Array, old_positions: PackedVector2Array) -> void:
+func _init(s: SS2D_Shape, keys: PackedInt32Array, old_positions: PackedVector2Array) -> void:
 	_shape = s
 	_keys = keys.duplicate()
 	_old_positions = old_positions.duplicate()

--- a/addons/rmsmartshape/actions/action_split_shape.gd
+++ b/addons/rmsmartshape/actions/action_split_shape.gd
@@ -50,7 +50,7 @@ func do() -> void:
 		_splitted.collision_polygon_node_path = _splitted.get_path_to(_splitted_collision)
 
 	if _delete_points_from_original == null:
-		var delete_keys := PackedInt64Array()
+		var delete_keys := PackedInt32Array()
 		for i in range(_shape.get_point_count() - 1, _split_idx, -1):
 			delete_keys.append(_shape.get_point_key_at_index(i))
 		_delete_points_from_original = ActionDeletePoints.new(_shape, delete_keys)

--- a/addons/rmsmartshape/lib/tuple.gd
+++ b/addons/rmsmartshape/lib/tuple.gd
@@ -89,7 +89,7 @@ static func dict_validate(dict: Dictionary, value_type: Variant = null) -> void:
 		if value_type != null:
 			assert(is_instance_of(value, value_type), "Incorrect value type in dictionary: " + var_to_str(value))
 
-		if key is Array:
+		if key is Array or key is PackedInt32Array or key is PackedInt64Array:
 			var converted := Vector2i(int(key[0]), int(key[1]))
 			dict.erase(key)
 			dict[converted] = value

--- a/addons/rmsmartshape/lib/tuple.gd
+++ b/addons/rmsmartshape/lib/tuple.gd
@@ -46,8 +46,8 @@ static func array_has(tuple_array: Array[Vector2i], t: Vector2i) -> bool:
 
 
 ## Returns a list indices to tuples that contain the given value.
-static func array_find_partial(tuple_array: Array[Vector2i], value: int) -> Array[int]:
-	var out: Array[int] = []
+static func array_find_partial(tuple_array: Array[Vector2i], value: int) -> PackedInt32Array:
+	var out := PackedInt32Array()
 
 	for i in tuple_array.size():
 		if tuple_array[i].x == value or tuple_array[i].y == value:
@@ -56,11 +56,20 @@ static func array_find_partial(tuple_array: Array[Vector2i], value: int) -> Arra
 	return out
 
 
-## Returns a tuple with elements in ascending order.
+## Transform the tuple into a normalized representation (elements in ascending order).
+## Same as sort_ascending() at the moment.
+## Useful in more optimized use-cases where certain assumptions can be made if all tuples share a
+## normalized representation.
 static func normalize_tuple(tuple: Vector2i) -> Vector2i:
+	return sort_ascending(tuple)
+
+
+## Returns a tuple with elements in ascending order.
+static func sort_ascending(tuple: Vector2i) -> Vector2i:
 	if tuple.x <= tuple.y:
 		return tuple
 	return flip_elements(tuple)
+
 
 
 ## Returns a tuple with x and y components switched.

--- a/addons/rmsmartshape/lib/tuple.gd
+++ b/addons/rmsmartshape/lib/tuple.gd
@@ -1,48 +1,133 @@
 @tool
 extends RefCounted
+class_name SS2D_IndexTuple
 
-## Everything in this script should be static.
+## Provides utility functions for handling and storing indices of two related points using Vector2i.
 ##
-## This script contains code that may referenced in multiple locations in the plugin.
+## Index tuples are considered equal if their elements are equal, regardless of their order:
+## T(X, Y) <=> T(Y, X).
 ##
-## This is a simple script for a *very* simple tuple class
-## Some notes:
-## - "tuples" are just an array with two elements
-## - Only integer Tuples are fully supported
-## - Tuple(X,Y) is equal to Tuple(Y,X)
+## For effectively working with containers, helper functions for arrays and dictionaries are
+## provided that implement the above behavior.
 
-
-static func create_tuple(a: int, b: int) -> Array[int]:
-	return [a, b]
-
-
-static func get_other_value_from_tuple(t: Array[int], value: int) -> int:
-	if t[0] == value:
-		return t[1]
-	elif t[1] == value:
-		return t[0]
+## Returns the second tuple element that does not equal the given value.
+## Returns -1 if neither element matches.
+static func get_other_value(t: Vector2i, value: int) -> int:
+	if t.x == value:
+		return t.y
+	elif t.y == value:
+		return t.x
 	return -1
 
 
-static func tuples_are_equal(t1: Array[int], t2: Array[int]) -> bool:
-	return (t1[0] == t2[0] and t1[1] == t2[1]) or (t1[0] == t2[1] and t1[1] == t2[0])
+## Returns whether two tuples are equal. Two tuples are considered equal when both contain the same values regardless of order.
+static func are_equal(t1: Vector2i, t2: Vector2i) -> bool:
+	return t1 == t2 or t1 == flip_elements(t2)
 
 
-static func find_tuple_in_array_of_tuples(tuple_array: Array, t: Array[int]) -> int:
-	for i in range(tuple_array.size()):
-		var other: Array[int] = []
-		other.assign(tuple_array[i])
-		if tuples_are_equal(t, other):
+## Returns true when the tuple contains the given value.
+static func has(t: Vector2i, value: int) -> bool:
+	return t.x == value or t.y == value
+
+
+## Searches for an equal tuple in the given array and returns the index or -1 if not found.
+## Incorporates the equality behavior.
+static func array_find(tuple_array: Array[Vector2i], t: Vector2i) -> int:
+	for i in tuple_array.size():
+		if are_equal(tuple_array[i], t):
 			return i
 	return -1
 
 
-static func is_tuple_in_array_of_tuples(tuple_array: Array, t: Array[int]) -> bool:
-	return find_tuple_in_array_of_tuples(tuple_array, t) != -1
+## Returns whether the given tuple exists in the given array.
+## Incorporates the equality behavior.
+static func array_has(tuple_array: Array[Vector2i], t: Vector2i) -> bool:
+	return array_find(tuple_array, t) != -1
 
 
-static func is_tuple(thing: Variant) -> bool:
-	if not thing is Array:
-		return false
-	var arr := thing as Array
-	return arr and arr.size() == 2
+## Returns a list indices to tuples that contain the given value.
+static func array_find_partial(tuple_array: Array[Vector2i], value: int) -> Array[int]:
+	var out: Array[int] = []
+
+	for i in tuple_array.size():
+		if tuple_array[i].x == value or tuple_array[i].y == value:
+			out.push_back(i)
+
+	return out
+
+
+## Returns a tuple with elements in ascending order.
+static func normalize_tuple(tuple: Vector2i) -> Vector2i:
+	if tuple.x <= tuple.y:
+		return tuple
+	return flip_elements(tuple)
+
+
+## Returns a tuple with x and y components switched.
+static func flip_elements(tuple: Vector2i) -> Vector2i:
+	return Vector2i(tuple.y, tuple.x)
+
+
+## Validates the keys of a dictionary to be correct tuple values and converts all Arrays to
+## corresponding Vector2i values.
+## Optionally also validates that values are of the given type.
+## Exists mostly for backwards compatibility to allow a seamless transition from Array to Vector2i tuples.
+static func dict_validate(dict: Dictionary, value_type: Variant = null) -> void:
+	# TODO: Maybe don't use asserts but push_warning and return true if successful
+	for key: Variant in dict.keys():
+		var value: Variant = dict[key]
+
+		if value_type != null:
+			assert(is_instance_of(value, value_type), "Incorrect value type in dictionary: " + var_to_str(value))
+
+		if key is Array:
+			var converted := Vector2i(int(key[0]), int(key[1]))
+			dict.erase(key)
+			dict[converted] = value
+		else:
+			assert(key is Vector2i, "Invalid tuple representation: %s. Should be Vector2i." % var_to_str(key))
+
+
+## Get the value in a dictionary with the given tuple as key or a default value if it does not exist.
+## Incorporates the equality behavior.
+static func dict_get(dict: Dictionary, tuple: Vector2i, default: Variant = null) -> Variant:
+	if dict.has(tuple):
+		return dict[tuple]
+	return dict.get(flip_elements(tuple), default)
+
+
+static func dict_has(dict: Dictionary, tuple: Vector2i) -> bool:
+	return dict.has(tuple) or dict.has(flip_elements(tuple))
+
+
+static func dict_set(dict: Dictionary, tuple: Vector2i, value: Variant) -> void:
+	dict[dict_get_key(dict, tuple)] = value
+
+
+## Removes the given entry from the dictionary. Returns true if a corresponding key existed, otherwise false.
+static func dict_erase(dict: Dictionary, tuple: Vector2i) -> bool:
+	return dict.erase(dict_get_key(dict, tuple))
+
+
+## Checks if there is an existing key for the given tuple or its flipped variant and returns it.
+## If a key does not exist, returns the tuple as it is.
+## Usually this function does not need to be invoked manually, as helpers for dictionary and array access exist.
+static func dict_get_key(dict: Dictionary, tuple: Vector2i) -> Vector2i:
+	if not dict.has(tuple):
+		var flipped := flip_elements(tuple)
+
+		if dict.has(flipped):
+			return flipped
+
+	return tuple
+
+
+## Returns a list of all dictionary keys (tuples) that contain the given value.
+static func dict_find_partial(dict: Dictionary, value: int) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+
+	for t: Vector2i in dict.keys():
+		if t.x == value or t.y == value:
+			out.push_back(t)
+
+	return out

--- a/addons/rmsmartshape/plugin.gd
+++ b/addons/rmsmartshape/plugin.gd
@@ -64,18 +64,18 @@ class ActionDataVert:
 	#Type of Action from the ACTION_VERT enum
 	var type: ACTION_VERT = ACTION_VERT.NONE
 	# The affected Verticies and their initial positions
-	var keys: Array[int] = []
-	var starting_width: Array[float] = []
+	var keys: PackedInt32Array
+	var starting_width: PackedFloat32Array
 	var starting_positions: PackedVector2Array = []
 	var starting_positions_control_in: PackedVector2Array = []
 	var starting_positions_control_out: PackedVector2Array = []
 
 	func _init(
-		_keys: Array[int],
+		_keys: PackedInt32Array,
 		positions: PackedVector2Array,
 		positions_in: PackedVector2Array,
 		positions_out: PackedVector2Array,
-		width: Array[float],
+		width: PackedFloat32Array,
 		t: ACTION_VERT
 	) -> void:
 		type = t
@@ -89,13 +89,10 @@ class ActionDataVert:
 		return keys.size() > 0
 
 	func _to_string() -> String:
-		var s := "%s: %s = %s"
-		return s % [type, keys, starting_positions]
+		return "%s: %s = %s" % [type, keys, starting_positions]
 
 	func is_single_vert_selected() -> bool:
-		if keys.size() == 1:
-			return true
-		return false
+		return keys.size() == 1
 
 	func current_point_key() -> int:
 		if not is_single_vert_selected():
@@ -960,11 +957,11 @@ func deselect_verts() -> void:
 	current_action = ActionDataVert.new([], [], [], [], [], ACTION_VERT.NONE)
 
 
-func select_verticies(keys: Array[int], action: ACTION_VERT) -> ActionDataVert:
+func select_verticies(keys: PackedInt32Array, action: ACTION_VERT) -> ActionDataVert:
 	var from_positions := PackedVector2Array()
 	var from_positions_c_in := PackedVector2Array()
 	var from_positions_c_out := PackedVector2Array()
-	var from_widths: Array[float] = []
+	var from_widths := PackedFloat32Array()
 	for key in keys:
 		from_positions.push_back(shape.get_point_position(key))
 		from_positions_c_in.push_back(shape.get_point_in(key))
@@ -975,19 +972,19 @@ func select_verticies(keys: Array[int], action: ACTION_VERT) -> ActionDataVert:
 	)
 
 
-func select_vertices_to_move(keys: Array[int], _mouse_starting_pos_viewport: Vector2) -> void:
+func select_vertices_to_move(keys: PackedInt32Array, _mouse_starting_pos_viewport: Vector2) -> void:
 	_mouse_motion_delta_starting_pos = _mouse_starting_pos_viewport
 	current_action = select_verticies(keys, ACTION_VERT.MOVE_VERT)
 
 
 func select_control_points_to_move(
-	keys: Array[int], _mouse_starting_pos_viewport: Vector2, action: ACTION_VERT = ACTION_VERT.MOVE_CONTROL
+	keys: PackedInt32Array, _mouse_starting_pos_viewport: Vector2, action: ACTION_VERT = ACTION_VERT.MOVE_CONTROL
 ) -> void:
 	current_action = select_verticies(keys, action)
 	_mouse_motion_delta_starting_pos = _mouse_starting_pos_viewport
 
 
-func select_width_handle_to_move(keys: Array[int], _mouse_starting_pos_viewport: Vector2) -> void:
+func select_width_handle_to_move(keys: PackedInt32Array, _mouse_starting_pos_viewport: Vector2) -> void:
 	_mouse_motion_delta_starting_pos = _mouse_starting_pos_viewport
 	current_action = select_verticies(keys, ACTION_VERT.MOVE_WIDTH_HANDLE)
 
@@ -1324,10 +1321,10 @@ func _input_split_edge(mb: InputEventMouseButton, vp_m_pos: Vector2, t: Transfor
 
 
 func _input_move_control_points(mb: InputEventMouseButton, vp_m_pos: Vector2, grab_threshold: float) -> bool:
-	var points_in: Array[int] = FUNC.get_intersecting_control_point_in(
+	var points_in := SS2D_PluginFunctionality.get_intersecting_control_point_in(
 		shape, get_et(), mb.position, grab_threshold
 	)
-	var points_out: Array[int] = FUNC.get_intersecting_control_point_out(
+	var points_out := SS2D_PluginFunctionality.get_intersecting_control_point_out(
 		shape, get_et(), mb.position, grab_threshold
 	)
 	if not points_in.is_empty():

--- a/addons/rmsmartshape/plugin_functionality.gd
+++ b/addons/rmsmartshape/plugin_functionality.gd
@@ -13,20 +13,20 @@ extends RefCounted
 
 static func get_intersecting_control_point_in(
 	s: SS2D_Shape, et: Transform2D, mouse_pos: Vector2, grab_threshold: float
-) -> Array[int]:
+) -> PackedInt32Array:
 	return _get_intersecting_control_point(s, et, mouse_pos, grab_threshold, true)
 
 
 static func get_intersecting_control_point_out(
 	s: SS2D_Shape, et: Transform2D, mouse_pos: Vector2, grab_threshold: float
-) -> Array[int]:
+) -> PackedInt32Array:
 	return _get_intersecting_control_point(s, et, mouse_pos, grab_threshold, false)
 
 
 static func _get_intersecting_control_point(
 	s: SS2D_Shape, et: Transform2D, mouse_pos: Vector2, grab_threshold: float, _in: bool
-) -> Array[int]:
-	var points: Array[int] = []
+) -> PackedInt32Array:
+	var points := PackedInt32Array()
 	var xform: Transform2D = et * s.get_global_transform()
 	for i in s.get_point_count():
 		var key: int = s.get_point_key_at_index(i)

--- a/addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.gd
+++ b/addons/rmsmartshape/scenes/GUI_Edge_InfoPanel.gd
@@ -2,14 +2,13 @@
 extends PanelContainer
 class_name SS2D_EdgeInfoPanel
 
-
 signal material_override_toggled(enabled: bool)
 signal render_toggled(enabled: bool)
 signal weld_toggled(enabled: bool)
 signal z_index_changed(value: int)
 signal edge_material_changed(value: SS2D_Material_Edge)
 
-var indicies: Array[int] = [-1, -1] : set = set_indicies
+var indicies := Vector2i(-1, -1) : set = set_indicies
 var edge_material: SS2D_Material_Edge = null
 var edge_material_selector := FileDialog.new()
 
@@ -63,9 +62,9 @@ func _on_set_edge_material_file_selected(f: String) -> void:
 	set_edge_material(rsc)
 
 
-func set_indicies(a: Array[int]) -> void:
-	indicies = a
-	idx_label.text = "IDX: [%s, %s]" % [indicies[0], indicies[1]]
+func set_indicies(t: Vector2i) -> void:
+	indicies = t
+	idx_label.text = "IDX: %s" % indicies
 
 
 func set_material_override(enabled: bool) -> void:

--- a/addons/rmsmartshape/shapes/index_map.gd
+++ b/addons/rmsmartshape/shapes/index_map.gd
@@ -171,7 +171,7 @@ func _split_indicies_into_multiple_mappings(new_indicies: PackedInt32Array) -> A
 ##
 ## This may split the IndexMap or make it invalid entirely.
 ## As a result, the returned array could have 0 or several IndexMaps.
-func remove_indicies(to_remove: Array[int]) -> Array[SS2D_IndexMap]:
+func remove_indicies(to_remove: PackedInt32Array) -> Array[SS2D_IndexMap]:
 	var out: Array[SS2D_IndexMap] = []
 	var new_indicies := indicies.duplicate()
 
@@ -202,7 +202,7 @@ func remove_indicies(to_remove: Array[int]) -> Array[SS2D_IndexMap]:
 ##
 ## This may split the IndexMap or make it invalid entirely.
 ## As a result, the returned array could have 0 or several IndexMaps.
-func remove_edges(to_remove: Array[int]) -> Array[SS2D_IndexMap]:
+func remove_edges(to_remove: PackedInt32Array) -> Array[SS2D_IndexMap]:
 	# Corner case
 	if to_remove.size() == 2:
 		var idx: int = indicies.find(to_remove[0])
@@ -224,7 +224,7 @@ func remove_edges(to_remove: Array[int]) -> Array[SS2D_IndexMap]:
 	for i in range(0, to_remove.size() - 1, 1):
 		var idx1: int = to_remove[i]
 		var idx2: int = to_remove[i + 1]
-		var edges_to_remove: Array[int] = []
+		var edges_to_remove := PackedInt32Array()
 		for ii in new_edges.size():
 			var edge := new_edges[ii]
 			if (edge[0] == idx1 or edge[0] == idx2) and (edge[1] == idx1 or edge[1] == idx2):

--- a/addons/rmsmartshape/shapes/point_array.gd
+++ b/addons/rmsmartshape/shapes/point_array.gd
@@ -189,7 +189,7 @@ func _unhook_point(p: SS2D_Point) -> void:
 
 
 func is_index_in_range(idx: int) -> bool:
-	return idx > 0 and idx < _point_order.size()
+	return idx >= 0 and idx < _point_order.size()
 
 
 func get_point_key_at_index(idx: int) -> int:

--- a/addons/rmsmartshape/shapes/point_array.gd
+++ b/addons/rmsmartshape/shapes/point_array.gd
@@ -655,8 +655,10 @@ func _update_cache() -> void:
 	# Point 0 will be the same on both the curve points and the vertices
 	# Point size - 1 will be the same on both the curve points and the vertices
 	_tesselation_cache = _curve.tessellate(tessellation_stages, tessellation_tolerance)
-	_tesselation_cache[0] = _curve.get_point_position(0)
-	_tesselation_cache[_tesselation_cache.size() - 1] = _curve.get_point_position(_curve.get_point_count() - 1)
+
+	if _tesselation_cache.size() >= 2:
+		_tesselation_cache[0] = _curve.get_point_position(0)
+		_tesselation_cache[-1] = _curve.get_point_position(_curve.get_point_count() - 1)
 
 	_tess_vertex_mapping.build(_tesselation_cache, _vertex_cache)
 

--- a/addons/rmsmartshape/shapes/point_array.gd
+++ b/addons/rmsmartshape/shapes/point_array.gd
@@ -2,21 +2,22 @@
 extends Resource
 class_name SS2D_Point_Array
 
-const TUP = preload("../lib/tuple.gd")
-
 enum CONSTRAINT { NONE = 0, AXIS_X = 1, AXIS_Y = 2, CONTROL_POINTS = 4, PROPERTIES = 8, ALL = 15 }
 
 # Maps a key to each point: Dict[int, SS2D_Point]
 @export var _points: Dictionary = {} : set = _set_points
 # Contains all keys; the order of the keys determines the order of the points
 @export var _point_order: Array[int] = [] : set = set_point_order
-# Key is tuple of point_keys; Value is the CONSTRAINT enum: Dict[Array[int], CONSTRAINT]
+
+## Dict[Vector2i, CONSTRAINT]
+## Key is tuple of point_keys; Value is the CONSTRAINT enum.
 @export var _constraints: Dictionary = {} : set = _set_constraints
 # Next key value to generate
 @export var _next_key: int = 0 : set = set_next_key
-# Dictionary of specific materials to use for specific tuples of points
-# Key is tuple of two point keys
-# Value is material
+
+## Dict[Vector2i, SS2D_Material_Edge_Metadata]
+## Dictionary of specific materials to use for specific tuples of points.
+## Key is tuple of two point keys, value is material.
 @export var _material_overrides: Dictionary = {} : set = set_material_overrides
 
 ## Controls how many subdivisions a curve segment may face before it is considered
@@ -32,6 +33,9 @@ var tessellation_tolerance: float = 4.0 : set = set_tessellation_tolerance
 @export_range(1, 512) var curve_bake_interval: float = 20.0 : set = set_curve_bake_interval
 
 var _constraints_enabled: bool = true
+var _updating_constraints := false
+var _keys_to_update_constraints: Array[int] = []
+
 var _changed_during_update := false
 var _updating := false
 
@@ -50,7 +54,7 @@ var _tess_vertex_mapping := SS2D_TesselationVertexMapping.new()
 signal update_finished()
 
 signal constraint_removed(key1: int, key2: int)
-signal material_override_changed(tuple: Array[int])
+signal material_override_changed(tuple: Vector2i)
 
 ###################
 # HANDLING POINTS #
@@ -84,14 +88,8 @@ func clone(deep: bool = false) -> SS2D_Point_Array:
 			new_point_dict[k] = get_point(k).duplicate(true)
 		copy._points = new_point_dict
 		copy._point_order = _point_order.duplicate(true)
-
-		copy._constraints = {}
-		for tuple: Array[int] in _constraints:
-			copy._constraints[tuple] = _constraints[tuple]
-
-		copy._material_overrides = {}
-		for tuple: Array[int] in _material_overrides:
-			copy._material_overrides[tuple] = _material_overrides[tuple]
+		copy._constraints = _constraints.duplicate()
+		copy._material_overrides = _material_overrides.duplicate()
 	else:
 		copy._points = _points
 		copy._point_order = _point_order
@@ -117,18 +115,9 @@ func set_point_order(po: Array[int]) -> void:
 func _set_constraints(cs: Dictionary) -> void:
 	_constraints = cs
 
-	# Fix for Backwards Compatibility with Godot 3.x
+	# For backwards compatibility (Array to Vector2i transition)
 	if Engine.is_editor_hint():
-		for tuple: Array[int] in _constraints:
-			if not tuple is Array:
-				push_error("Constraints Dictionary should have the following structure: key is a tuple of point_keys and value is the CONSTRAINT enum")
-			elif tuple.get_typed_builtin() != TYPE_INT:
-				# Try to convert
-				var new_tuple: Array[int] = []
-				new_tuple.assign(tuple)
-				var constraint: CONSTRAINT = _constraints[tuple]
-				_constraints.erase(tuple)
-				_constraints[new_tuple] = constraint
+		SS2D_IndexTuple.dict_validate(_constraints, TYPE_INT)
 
 
 func set_next_key(i: int) -> void:
@@ -154,11 +143,7 @@ func get_next_key() -> int:
 
 
 func is_key_valid(k: int) -> bool:
-	if k < 0:
-		return false
-	if _points.has(k):
-		return false
-	return true
+	return k >= 0 and not _points.has(k)
 
 
 ## Add a point.[br]
@@ -209,6 +194,13 @@ func is_index_in_range(idx: int) -> bool:
 
 func get_point_key_at_index(idx: int) -> int:
 	return _point_order[idx]
+
+
+func get_edge_keys_for_indices(indices: Vector2i) -> Vector2i:
+	return Vector2i(
+		get_point_key_at_index(indices.x),
+		get_point_key_at_index(indices.y)
+	)
 
 
 func get_point_at_index(idx: int) -> SS2D_Point:
@@ -405,9 +397,6 @@ func _changed() -> void:
 # CONSTRAINTS #
 ###############
 
-var _updating_constraints := false
-var _keys_to_update_constraints: Array[int] = []
-
 
 func disable_constraints() -> void:
 	_constraints_enabled = false
@@ -420,12 +409,17 @@ func enable_constraints() -> void:
 func _update_constraints(src: int) -> void:
 	if not _constraints_enabled:
 		return
-	var constraints: Dictionary = get_point_constraints(src)
-	for tuple: Array[int] in constraints:
-		var constraint: CONSTRAINT = constraints[tuple]
+
+	var constraints := get_point_constraints_tuples(src)
+
+	for tuple in constraints:
+		var constraint: CONSTRAINT = SS2D_IndexTuple.dict_get(_constraints, tuple)
+
 		if constraint == CONSTRAINT.NONE:
 			continue
-		var dst: int = TUP.get_other_value_from_tuple(tuple, src)
+
+		var dst: int = SS2D_IndexTuple.get_other_value(tuple, src)
+
 		if constraint & CONSTRAINT.AXIS_X:
 			set_point_position(dst, Vector2(get_point_position(src).x, get_point_position(dst).y))
 		if constraint & CONSTRAINT.AXIS_Y:
@@ -442,6 +436,7 @@ func _update_constraints(src: int) -> void:
 func update_constraints(src: int) -> void:
 	if not has_point(src) or _updating_constraints:
 		return
+
 	_updating_constraints = true
 	# Initial pass of updating constraints
 	_update_constraints(src)
@@ -457,59 +452,50 @@ func update_constraints(src: int) -> void:
 	_changed()
 
 
-## Will Return all constraints for a given key.
+## Returns all point constraint that include the given point key.
+## Returns a Dictionary[Vector2i, CONSTRAINT].
 func get_point_constraints(key1: int) -> Dictionary:
 	var constraints := {}
-	for tuple: Array[int] in _constraints:
-		if tuple.has(key1):
-			constraints[tuple] = _constraints[tuple]
+	var tuples := get_point_constraints_tuples(key1)
+
+	for t in tuples:
+		constraints[t] = get_point_constraint(t.x, t.y)
+
 	return constraints
 
 
-## Will Return the constraint for a pair of keys.
+## Returns all point constraint tuples that include the given point key.
+func get_point_constraints_tuples(key1: int) -> Array[Vector2i]:
+	return SS2D_IndexTuple.dict_find_partial(_constraints, key1)
+
+
+## Returns the constraint for a pair of keys.
 func get_point_constraint(key1: int, key2: int) -> CONSTRAINT:
-	var t := TUP.create_tuple(key1, key2)
-	var keys: Array = _constraints.keys()  # Array[Array[int]]
-	var t_index: int = TUP.find_tuple_in_array_of_tuples(keys, t)
-	if t_index == -1:
-		return CONSTRAINT.NONE
-	var t_key: Array = keys[t_index]
-	return _constraints[t_key]
+	return SS2D_IndexTuple.dict_get(_constraints, Vector2i(key1, key2), CONSTRAINT.NONE)
 
 
 func set_constraint(key1: int, key2: int, constraint: CONSTRAINT) -> void:
-	var t := TUP.create_tuple(key1, key2)
-	var existing_tuples: Array = _constraints.keys()  # Array[Array[int]]
-	var existing_t_index: int = TUP.find_tuple_in_array_of_tuples(existing_tuples, t)
-	if existing_t_index != -1:
-		t = existing_tuples[existing_t_index]
-	_constraints[t] = constraint
-	if _constraints[t] == CONSTRAINT.NONE:
-		_constraints.erase(t)
-		emit_signal("constraint_removed", key1, key2)
-	else:
-		update_constraints(key1)
+	var t := Vector2i(key1, key2)
+
+	if constraint == CONSTRAINT.NONE:
+		remove_constraint(t)
+		return
+
+	SS2D_IndexTuple.dict_set(_constraints, t, constraint)
+	update_constraints(key1)
 	_changed()
 
 
+## Remove all constraints involving the given point key.
 func remove_constraints(key1: int) -> void:
-	var constraints: Dictionary = get_point_constraints(key1)
-	for tuple: Array[int] in constraints:
-		var key2: int = TUP.get_other_value_from_tuple(tuple, key1)
-		set_constraint(key1, key2, CONSTRAINT.NONE)
+	for tuple in get_point_constraints_tuples(key1):
+		remove_constraint(tuple)
 
 
-func remove_constraint(key1: int, key2: int) -> void:
-	set_constraint(key1, key2, CONSTRAINT.NONE)
-
-
-func get_all_constraints_of_type(type: CONSTRAINT) -> Array[TUP]:
-	var constraints: Array[TUP] = []
-	for t: Array[int] in _constraints:
-		var c: CONSTRAINT = _constraints[t]
-		if c == type:
-			constraints.push_back(t)
-	return constraints
+## Remove the constraint between the two point indices of the given tuple.
+func remove_constraint(point_index_tuple: Vector2i) -> void:
+	if SS2D_IndexTuple.dict_erase(_constraints, point_index_tuple):
+		emit_signal("constraint_removed", point_index_tuple.x, point_index_tuple.y)
 
 
 ########
@@ -526,71 +512,66 @@ func debug_print() -> void:
 ######################
 # MATERIAL OVERRIDES #
 ######################
-## dict: Dict[Array[int], SS2D_Material_Edge_Metadata]
+## dict: Dict[Vector2i, SS2D_Material_Edge_Metadata]
 func set_material_overrides(dict: Dictionary) -> void:
-	for k: Variant in dict:
-		if not TUP.is_tuple(k):
-			push_error("Material Override Dictionary KEY is not an Array with 2 points!")
-		if not dict[k] is SS2D_Material_Edge_Metadata:
-			push_error("Material Override Dictionary VALUE is not SS2D_Material_Edge_Metadata!")
+	SS2D_IndexTuple.dict_validate(dict, SS2D_Material_Edge_Metadata)
 
 	if _material_overrides != null:
 		for old: SS2D_Material_Edge_Metadata in _material_overrides.values():
-			if old.is_connected("changed", self._on_material_override_changed):
-				old.disconnect("changed", self._on_material_override_changed)
+			_unhook_mat(old)
 
 	_material_overrides = dict
-	for tuple: Array[int] in _material_overrides:
-		var m: SS2D_Material_Edge_Metadata = _material_overrides[tuple]
-		m.connect("changed", self._on_material_override_changed.bind(tuple))
+
+	for tuple: Vector2i in _material_overrides:
+		_hook_mat(tuple, _material_overrides[tuple])
 
 
-func get_material_override_tuple(tuple: Array[int]) -> Array[int]:
-	var keys: Array = _material_overrides.keys()  # Array[Array[int]]
-	var idx: int = TUP.find_tuple_in_array_of_tuples(keys, tuple)
-	if idx != -1:
-		tuple = keys[idx]
-	return tuple
+func has_material_override(tuple: Vector2i) -> bool:
+	return SS2D_IndexTuple.dict_has(_material_overrides, tuple)
 
 
-func has_material_override(tuple: Array[int]) -> bool:
-	tuple = get_material_override_tuple(tuple)
-	return _material_overrides.has(tuple)
-
-
-func remove_material_override(tuple: Array[int]) -> void:
-	if not has_material_override(tuple):
-		return
+func remove_material_override(tuple: Vector2i) -> void:
 	var old := get_material_override(tuple)
-	if old.is_connected("changed", self._on_material_override_changed):
-		old.disconnect("changed", self._on_material_override_changed)
-	_material_overrides.erase(get_material_override_tuple(tuple))
-	_on_material_override_changed(tuple)
+
+	if old != null:
+		_unhook_mat(old)
+		SS2D_IndexTuple.dict_erase(_material_overrides, tuple)
+		_on_material_override_changed(tuple)
 
 
-func set_material_override(tuple: Array[int], mat: SS2D_Material_Edge_Metadata) -> void:
-	if has_material_override(tuple):
-		var old := get_material_override(tuple)
+func set_material_override(tuple: Vector2i, mat: SS2D_Material_Edge_Metadata) -> void:
+	var old := get_material_override(tuple)
+
+	if old != null:
 		if old == mat:
 			return
 		else:
-			if old.is_connected("changed", self._on_material_override_changed):
-				old.disconnect("changed", self._on_material_override_changed)
-	if not mat.is_connected("changed", self._on_material_override_changed):
-		mat.connect("changed", self._on_material_override_changed.bind(tuple))
-	_material_overrides[get_material_override_tuple(tuple)] = mat
+			_unhook_mat(old)
+
+	_hook_mat(tuple, mat)
+	SS2D_IndexTuple.dict_set(_material_overrides, tuple, mat)
 	_on_material_override_changed(tuple)
 
 
-func get_material_override(tuple: Array[int]) -> SS2D_Material_Edge_Metadata:
-	if not has_material_override(tuple):
-		return null
-	return _material_overrides[get_material_override_tuple(tuple)]
+## Returns the material override for the edge defined by the given point index tuple, or null if
+## there is no override.
+func get_material_override(tuple: Vector2i) -> SS2D_Material_Edge_Metadata:
+	return SS2D_IndexTuple.dict_get(_material_overrides, tuple)
+
+
+func _hook_mat(tuple: Vector2i, mat: SS2D_Material_Edge_Metadata) -> void:
+	if not mat.changed.is_connected(_on_material_override_changed):
+		mat.changed.connect(_on_material_override_changed.bind(tuple))
+
+
+func _unhook_mat(mat: SS2D_Material_Edge_Metadata) -> void:
+	if mat.changed.is_connected(_on_material_override_changed):
+		mat.changed.disconnect(_on_material_override_changed)
 
 
 ## Returns a dictionary of specific materials to use for specific tuples of points.[br]
 ## Key is tuple of two point keys, value is material.[br]
-## => Dict[Array[int], SS2D_Material_Edge_Metadata]
+## => Dict[Vector2i, SS2D_Material_Edge_Metadata]
 func get_material_overrides() -> Dictionary:
 	return _material_overrides
 
@@ -686,5 +667,5 @@ func _to_string() -> String:
 	return "<SS2D_Point_Array points: %s order: %s>" % [_points.keys(), _point_order]
 
 
-func _on_material_override_changed(tuple: Array[int]) -> void:
-	emit_signal("material_override_changed", tuple)
+func _on_material_override_changed(tuple: Vector2i) -> void:
+	material_override_changed.emit(tuple)

--- a/addons/rmsmartshape/shapes/point_array.gd
+++ b/addons/rmsmartshape/shapes/point_array.gd
@@ -115,8 +115,8 @@ func _set_constraints(cs: Dictionary) -> void:
 	_constraints = cs
 
 	# For backwards compatibility (Array to Vector2i transition)
-	if Engine.is_editor_hint():
-		SS2D_IndexTuple.dict_validate(_constraints, TYPE_INT)
+	# FIXME: Maybe remove during the next breaking release
+	SS2D_IndexTuple.dict_validate(_constraints, TYPE_INT)
 
 
 func set_next_key(i: int) -> void:
@@ -514,6 +514,8 @@ func debug_print() -> void:
 ######################
 ## dict: Dict[Vector2i, SS2D_Material_Edge_Metadata]
 func set_material_overrides(dict: Dictionary) -> void:
+	# For backwards compatibility (Array to Vector2i transition)
+	# FIXME: Maybe remove during the next breaking release
 	SS2D_IndexTuple.dict_validate(dict, SS2D_Material_Edge_Metadata)
 
 	if _material_overrides != null:

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -338,9 +338,9 @@ func adjust_add_point_index(index: int) -> int:
 
 
 # FIXME: Only unit tests use this.
-func add_points(verts: PackedVector2Array, starting_index: int = -1, key: int = -1) -> Array[int]:
+func add_points(verts: PackedVector2Array, starting_index: int = -1, key: int = -1) -> PackedInt32Array:
 	starting_index = adjust_add_point_index(starting_index)
-	var keys: Array[int] = []
+	var keys := PackedInt32Array()
 	_points.begin_update()
 	for i in range(0, verts.size(), 1):
 		var v: Vector2 = verts[i]
@@ -511,7 +511,7 @@ func has_point(key: int) -> bool:
 
 ## Deprecated. Use respective function in get_point_array() instead.
 ## @deprecated
-func get_all_point_keys() -> Array[int]:
+func get_all_point_keys() -> PackedInt32Array:
 	return _points.get_all_point_keys()
 
 
@@ -1315,12 +1315,10 @@ static func get_meta_material_index_mapping_for_overrides(
 	_s_material: SS2D_Material_Shape, pa: SS2D_Point_Array
 ) -> Array[SS2D_IndexMap]:
 	var mappings: Array[SS2D_IndexMap] = []
-	var overrides := pa.get_material_overrides()
-	for key_tuple: Vector2i in overrides:
-		var indicies: Array[int] = [pa.get_point_index(key_tuple.x), pa.get_point_index(key_tuple.y)]
-		indicies = sort_by_int_ascending(indicies)
+	for key_tuple in pa.get_material_overrides():
+		var indices := SS2D_IndexTuple.sort_ascending(Vector2i(pa.get_point_index(key_tuple.x), pa.get_point_index(key_tuple.y)))
 		var m: SS2D_Material_Edge_Metadata = pa.get_material_override(key_tuple)
-		var new_mapping := SS2D_IndexMap.new(PackedInt32Array(indicies), m)
+		var new_mapping := SS2D_IndexMap.new(PackedInt32Array([ indices.x, indices.y ]), m)
 		mappings.push_back(new_mapping)
 
 	return mappings

--- a/tests/unit/test_edge.gd
+++ b/tests/unit/test_edge.gd
@@ -4,7 +4,7 @@ var TEST_TEXTURE: Texture2D = preload("res://tests/unit/test.png")
 
 
 func test_consecutive_quads() -> void:
-	var big_exclude: Array[int] = [2, 8, 34, 56, 78, 99, 123, 154, 198, 234]
+	var big_exclude: PackedInt32Array = [2, 8, 34, 56, 78, 99, 123, 154, 198, 234]
 	assert_eq(SS2D_Edge.get_consecutive_quads_for_mesh(generate_quads(256)).size(), 1)
 	assert_eq(
 		SS2D_Edge.get_consecutive_quads_for_mesh(generate_quads(256, null, big_exclude)).size(),
@@ -57,7 +57,7 @@ func test_generate_mesh_from_quad_sequence() -> void:
 func generate_quads(
 	amnt: int,
 	tex: Texture = null,
-	indicies_to_change: Array = [],
+	indicies_to_change: PackedInt32Array = [],
 	extents: Vector2 = Vector2(16.0, 16.0)
 ) -> Array[SS2D_Quad]:
 	var quads: Array[SS2D_Quad] = []

--- a/tests/unit/test_index_map.gd
+++ b/tests/unit/test_index_map.gd
@@ -7,7 +7,7 @@ func test_remove_indicies_basic() -> void:
 	var object := "OBJECT"
 	var indicies: Array[int] = [0,1,2,3,4,5,6,7,8]
 	var to_remove: Array[int] = [2,3,4,5]
-	var expected := [[0,1],[6,7,8]]
+	var expected := convert_segments_to_typed([[0,1],[6,7,8]])
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_indicies(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -23,7 +23,7 @@ func test_remove_indicies_basic_2() -> void:
 	var object := "OBJECT"
 	var indicies: Array[int] = [1,2,3,4,5,6,7,8]
 	var to_remove: Array[int] = [2,3,4,5]
-	var expected := [[6,7,8]]
+	var expected := convert_segments_to_typed([[6,7,8]])
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_indicies(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -48,7 +48,7 @@ func test_remove_indicies_unaffected() -> void:
 	var object := "OBJECT"
 	var indicies: Array[int] = [1,2,3,4,5,6]
 	var to_remove: Array[int] = [8,9,10]
-	var expected := [[1,2,3,4,5,6]]
+	var expected := convert_segments_to_typed([[1,2,3,4,5,6]])
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_indicies(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -66,7 +66,7 @@ func test_remove_edges_basic() -> void:
 	var object := "OBJECT"
 	var indicies: Array[int] = [0,1,2,3,4,5,6,7,8]
 	var to_remove: Array[int] = [2,3,4,5]
-	var expected := [[0,1,2],[5,6,7,8]]
+	var expected := convert_segments_to_typed([[0,1,2],[5,6,7,8]])
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_edges(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -82,7 +82,7 @@ func test_remove_edges_basic_2() -> void:
 	var object := "OBJECT"
 	var indicies: Array[int] = [0,1,2,3,4,5,6,7,8]
 	var to_remove: Array[int] = [3,4]
-	var expected := [[0,1,2,3],[4,5,6,7,8]]
+	var expected := convert_segments_to_typed([[0,1,2,3],[4,5,6,7,8]])
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_edges(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -99,7 +99,7 @@ func test_remove_edges_basic_3() -> void:
 	var object := "OBJECT"
 	var indicies: Array[int] = [2,3,4,5,6,7,8]
 	var to_remove: Array[int] = [2,3]
-	var expected := [[3,4,5,6,7,8]]
+	var expected := convert_segments_to_typed([[3,4,5,6,7,8]])
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_edges(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -113,38 +113,39 @@ func test_remove_edges_basic_3() -> void:
 # OTHER #
 #########
 
-func test_contiguous_segments() -> void:
-	var mm2i := new_index_map([1, 2, 3, 4, 5])
-	var segments := mm2i.get_contiguous_segments()
-	assert_eq(segments.size(), 1)
-	assert_eq(segments[0], [1,2,3,4,5])
-
-	mm2i = new_index_map([0, 1, 2,   4, 5,   7, 8,   10])
-	segments = mm2i.get_contiguous_segments()
-	assert_eq(segments.size(), 4)
-	assert_eq(segments[0], [0, 1, 2])
-	assert_eq(segments[1], [4,5])
-	assert_eq(segments[2], [7,8])
-	assert_eq(segments[3], [10])
+# FIXME: Unused. Remove eventually.
+# func test_contiguous_segments() -> void:
+# 	var mm2i := new_index_map([1, 2, 3, 4, 5])
+# 	var segments := mm2i.get_contiguous_segments()
+# 	assert_eq(segments.size(), 1)
+# 	assert_eq(segments[0], [1,2,3,4,5])
+#
+# 	mm2i = new_index_map([0, 1, 2,   4, 5,   7, 8,   10])
+# 	segments = mm2i.get_contiguous_segments()
+# 	assert_eq(segments.size(), 4)
+# 	assert_eq(segments[0], [0, 1, 2])
+# 	assert_eq(segments[1], [4,5])
+# 	assert_eq(segments[2], [7,8])
+# 	assert_eq(segments[3], [10])
 
 func test_join_segments() -> void:
 	# Test contains some points, but not all
-	var segments := [[0, 1, 2,3],  [4, 5],   [7, 8],   [5, 6, 7],   [8, 9, 10],   [10, 11]]
+	var segments: Array[PackedInt32Array] = [ [0, 1, 2, 3], [4, 5], [7, 8], [5, 6, 7], [8, 9, 10], [10, 11] ]
 	convert_segments_to_typed(segments)
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 
 	assert_eq(segments.size(), 2)
-	assert_eq(segments[0], [0,1,2,3])
-	assert_eq(segments[1], [4,5,6,7,8,9,10,11])
+	assert_eq(segments[0], PackedInt32Array([0,1,2,3]))
+	assert_eq(segments[1], PackedInt32Array([4,5,6,7,8,9,10,11]))
 
 	segments = [[0, 1], [1,2], [2,3], [4, 5],   [7, 8],   [5, 6, 7],   [8, 9, 10],   [10, 11]]
 	convert_segments_to_typed(segments)
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 	assert_eq(segments.size(), 2)
-	assert_eq(segments[0], [0,1,2,3])
-	assert_eq(segments[1], [4,5,6,7,8,9,10,11])
+	assert_eq(segments[0], PackedInt32Array([0,1,2,3]))
+	assert_eq(segments[1], PackedInt32Array([4,5,6,7,8,9,10,11]))
 
 	# Test wrap around
 	segments = [[0, 1, 2,3],  [4, 5],   [7, 8],   [5, 6, 7],   [8, 9, 10],   [10, 11, 0]]
@@ -152,7 +153,7 @@ func test_join_segments() -> void:
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 	assert_eq(segments.size(), 1)
-	assert_eq(segments[0], [4,5,6,7,8,9,10,11,0,1,2,3])
+	assert_eq(segments[0], PackedInt32Array([4,5,6,7,8,9,10,11,0,1,2,3]))
 
 	# Test contains all point pairs
 	segments = [[0, 1, 2,3,4],  [4, 5],   [7, 8],   [5, 6, 7],   [8, 9, 10],   [10, 11, 0]]
@@ -160,14 +161,17 @@ func test_join_segments() -> void:
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 	assert_eq(segments.size(), 1)
-	assert_eq(segments[0], [0,1,2,3,4,5,6,7,8,9,10,11,0])
+	assert_eq(segments[0], PackedInt32Array([0,1,2,3,4,5,6,7,8,9,10,11,0]))
 
 
 func test_index_order() -> void:
 	var indicies: Array[int] = [5, 4, 2, 3, 1]
 	var mm2i := new_index_map(indicies)
-	assert_eq(mm2i.highest_index(), 5)
-	assert_eq(mm2i.lowest_index(), 1)
+
+	# FIXME: Unused, remove eventually.
+	# assert_eq(mm2i.highest_index(), 5)
+	# assert_eq(mm2i.lowest_index(), 1)
+
 	assert_false(mm2i.is_contiguous())
 	assert_true(mm2i.is_valid())
 
@@ -202,16 +206,11 @@ func new_index_map(indicies: Array[int] = [1, 2, 3, 4, 5]) -> SS2D_IndexMap:
 
 
 # Convert Array[ Array ] -> Array[ Array[p_type] ]
-func convert_segments_to_typed(p_arr: Array, p_type: int = TYPE_INT) -> Array:
+func convert_segments_to_typed(p_arr: Array) -> Array[PackedInt32Array]:
+	var out: Array[PackedInt32Array] = []
 	for i in p_arr.size():
-		var a: Array = p_arr[i]
-		if not a is Array:
-			push_error("Element is not Array.")
-		elif a.get_typed_builtin() != p_type:
-			var new_a: Array[int] = []
-			new_a.assign(a)
-			p_arr[i] = new_a
-	return p_arr
+		out.push_back(PackedInt32Array(p_arr[i]))
+	return out
 
 
 func to_int_array(p_arr: Array) -> Array[int]:

--- a/tests/unit/test_index_map.gd
+++ b/tests/unit/test_index_map.gd
@@ -5,9 +5,9 @@ extends "res://addons/gut/test.gd"
 ###################
 func test_remove_indicies_basic() -> void:
 	var object := "OBJECT"
-	var indicies: Array[int] = [0,1,2,3,4,5,6,7,8]
-	var to_remove: Array[int] = [2,3,4,5]
-	var expected := convert_segments_to_typed([[0,1],[6,7,8]])
+	var indicies: PackedInt32Array = [0,1,2,3,4,5,6,7,8]
+	var to_remove: PackedInt32Array = [2,3,4,5]
+	var expected: Array[PackedInt32Array] = [[0,1],[6,7,8]]
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_indicies(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -21,9 +21,9 @@ func test_remove_indicies_basic() -> void:
 
 func test_remove_indicies_basic_2() -> void:
 	var object := "OBJECT"
-	var indicies: Array[int] = [1,2,3,4,5,6,7,8]
-	var to_remove: Array[int] = [2,3,4,5]
-	var expected := convert_segments_to_typed([[6,7,8]])
+	var indicies: PackedInt32Array = [1,2,3,4,5,6,7,8]
+	var to_remove: PackedInt32Array = [2,3,4,5]
+	var expected: Array[PackedInt32Array] = [[6,7,8]]
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_indicies(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -35,8 +35,8 @@ func test_remove_indicies_basic_2() -> void:
 
 func test_remove_indicies_none_remaining() -> void:
 	var object := "OBJECT"
-	var indicies: Array[int] = [1,2,3,4,5,6]
-	var to_remove: Array[int] = [2,3,4,5]
+	var indicies: PackedInt32Array = [1,2,3,4,5,6]
+	var to_remove: PackedInt32Array = [2,3,4,5]
 	var expected := []
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_indicies(to_remove)
@@ -46,9 +46,9 @@ func test_remove_indicies_none_remaining() -> void:
 
 func test_remove_indicies_unaffected() -> void:
 	var object := "OBJECT"
-	var indicies: Array[int] = [1,2,3,4,5,6]
-	var to_remove: Array[int] = [8,9,10]
-	var expected := convert_segments_to_typed([[1,2,3,4,5,6]])
+	var indicies: PackedInt32Array = [1,2,3,4,5,6]
+	var to_remove: PackedInt32Array = [8,9,10]
+	var expected: Array[PackedInt32Array] = [[1,2,3,4,5,6]]
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_indicies(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -64,9 +64,9 @@ func test_remove_indicies_unaffected() -> void:
 ################
 func test_remove_edges_basic() -> void:
 	var object := "OBJECT"
-	var indicies: Array[int] = [0,1,2,3,4,5,6,7,8]
-	var to_remove: Array[int] = [2,3,4,5]
-	var expected := convert_segments_to_typed([[0,1,2],[5,6,7,8]])
+	var indicies: PackedInt32Array = [0,1,2,3,4,5,6,7,8]
+	var to_remove: PackedInt32Array = [2,3,4,5]
+	var expected: Array[PackedInt32Array] = [[0,1,2],[5,6,7,8]]
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_edges(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -80,9 +80,9 @@ func test_remove_edges_basic() -> void:
 
 func test_remove_edges_basic_2() -> void:
 	var object := "OBJECT"
-	var indicies: Array[int] = [0,1,2,3,4,5,6,7,8]
-	var to_remove: Array[int] = [3,4]
-	var expected := convert_segments_to_typed([[0,1,2,3],[4,5,6,7,8]])
+	var indicies: PackedInt32Array = [0,1,2,3,4,5,6,7,8]
+	var to_remove: PackedInt32Array = [3,4]
+	var expected: Array[PackedInt32Array] = [[0,1,2,3],[4,5,6,7,8]]
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_edges(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -97,9 +97,9 @@ func test_remove_edges_basic_2() -> void:
 
 func test_remove_edges_basic_3() -> void:
 	var object := "OBJECT"
-	var indicies: Array[int] = [2,3,4,5,6,7,8]
-	var to_remove: Array[int] = [2,3]
-	var expected := convert_segments_to_typed([[3,4,5,6,7,8]])
+	var indicies: PackedInt32Array = [2,3,4,5,6,7,8]
+	var to_remove: PackedInt32Array = [2,3]
+	var expected: Array[PackedInt32Array] = [[3,4,5,6,7,8]]
 	var imap := SS2D_IndexMap.new(indicies, object)
 	var new_maps := imap.remove_edges(to_remove)
 	assert_eq(new_maps.size(), expected.size())
@@ -131,7 +131,6 @@ func test_remove_edges_basic_3() -> void:
 func test_join_segments() -> void:
 	# Test contains some points, but not all
 	var segments: Array[PackedInt32Array] = [ [0, 1, 2, 3], [4, 5], [7, 8], [5, 6, 7], [8, 9, 10], [10, 11] ]
-	convert_segments_to_typed(segments)
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 
@@ -140,7 +139,6 @@ func test_join_segments() -> void:
 	assert_eq(segments[1], PackedInt32Array([4,5,6,7,8,9,10,11]))
 
 	segments = [[0, 1], [1,2], [2,3], [4, 5],   [7, 8],   [5, 6, 7],   [8, 9, 10],   [10, 11]]
-	convert_segments_to_typed(segments)
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 	assert_eq(segments.size(), 2)
@@ -149,7 +147,6 @@ func test_join_segments() -> void:
 
 	# Test wrap around
 	segments = [[0, 1, 2,3],  [4, 5],   [7, 8],   [5, 6, 7],   [8, 9, 10],   [10, 11, 0]]
-	convert_segments_to_typed(segments)
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 	assert_eq(segments.size(), 1)
@@ -157,7 +154,6 @@ func test_join_segments() -> void:
 
 	# Test contains all point pairs
 	segments = [[0, 1, 2,3,4],  [4, 5],   [7, 8],   [5, 6, 7],   [8, 9, 10],   [10, 11, 0]]
-	convert_segments_to_typed(segments)
 	segments = SS2D_IndexMap.join_segments(segments)
 	gut.p(segments)
 	assert_eq(segments.size(), 1)
@@ -165,7 +161,7 @@ func test_join_segments() -> void:
 
 
 func test_index_order() -> void:
-	var indicies: Array[int] = [5, 4, 2, 3, 1]
+	var indicies: PackedInt32Array = [5, 4, 2, 3, 1]
 	var mm2i := new_index_map(indicies)
 
 	# FIXME: Unused, remove eventually.
@@ -179,13 +175,13 @@ func test_index_order() -> void:
 func test_contiguous() -> void:
 	var mm2i := new_index_map()
 
-	mm2i.indicies = to_int_array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+	mm2i.indicies = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 	assert_true(mm2i.is_contiguous())
-	mm2i.indicies = to_int_array([1, 2, 3, 4, 6, 7, 8, 9])
+	mm2i.indicies = [1, 2, 3, 4, 6, 7, 8, 9]
 	assert_false(mm2i.is_contiguous())
-	mm2i.indicies = to_int_array([4, 5, 9])
+	mm2i.indicies = [4, 5, 9]
 	assert_false(mm2i.is_contiguous())
-	mm2i.indicies = to_int_array([4, 8, 9])
+	mm2i.indicies = [4, 8, 9]
 	assert_false(mm2i.is_contiguous())
 
 
@@ -199,21 +195,7 @@ func test_duplicate() -> void:
 	assert_ne(a.indicies, b.indicies)
 
 
-func new_index_map(indicies: Array[int] = [1, 2, 3, 4, 5]) -> SS2D_IndexMap:
+func new_index_map(indicies: PackedInt32Array = [1, 2, 3, 4, 5]) -> SS2D_IndexMap:
 	var meta_mat := SS2D_Material_Edge_Metadata.new()
 	var mm2i := SS2D_IndexMap.new(indicies, meta_mat)
 	return mm2i
-
-
-# Convert Array[ Array ] -> Array[ Array[p_type] ]
-func convert_segments_to_typed(p_arr: Array) -> Array[PackedInt32Array]:
-	var out: Array[PackedInt32Array] = []
-	for i in p_arr.size():
-		out.push_back(PackedInt32Array(p_arr[i]))
-	return out
-
-
-func to_int_array(p_arr: Array) -> Array[int]:
-	var new_arr: Array[int] = []
-	new_arr.assign(p_arr)
-	return new_arr

--- a/tests/unit/test_point_array.gd
+++ b/tests/unit/test_point_array.gd
@@ -182,11 +182,11 @@ func test_material_override_add_delete() -> void:
 
 	# Add
 	assert_eq(0, pa.get_material_overrides().size())
-	pa.set_material_override([0,1], mmat1)
+	pa.set_material_override(Vector2i(0,1), mmat1)
 	assert_eq(1, pa.get_material_overrides().size())
-	pa.set_material_override([1,0], mmat1)
+	pa.set_material_override(Vector2i(1,0), mmat1)
 	assert_eq(1, pa.get_material_overrides().size())
-	pa.set_material_override([2,1], mmat2)
+	pa.set_material_override(Vector2i(2,1), mmat2)
 	assert_eq(2, pa.get_material_overrides().size())
 
 	assert_true(mmat1.is_connected("changed", pa._on_material_override_changed))
@@ -194,29 +194,29 @@ func test_material_override_add_delete() -> void:
 
 
 	# Get
-	assert_eq(null, pa.get_material_override([5,1]))
-	assert_eq(mmat1, pa.get_material_override([0,1]))
-	assert_eq(mmat2, pa.get_material_override([2,1]))
+	assert_eq(null, pa.get_material_override(Vector2i(5,1)))
+	assert_eq(mmat1, pa.get_material_override(Vector2i(0,1)))
+	assert_eq(mmat2, pa.get_material_override(Vector2i(2,1)))
 
 
 	# Has
-	assert_false(pa.has_material_override([5,1]))
-	assert_true(pa.has_material_override([0,1]))
-	assert_true(pa.has_material_override([2,1]))
+	assert_false(pa.has_material_override(Vector2i(5,1)))
+	assert_true(pa.has_material_override(Vector2i(0,1)))
+	assert_true(pa.has_material_override(Vector2i(2,1)))
 
 
 	# Overwrite
-	pa.set_material_override([1,0], mmat2)
-	assert_eq(mmat2, pa.get_material_override([0,1]))
+	pa.set_material_override(Vector2i(1,0), mmat2)
+	assert_eq(mmat2, pa.get_material_override(Vector2i(0,1)))
 
 	assert_false(mmat1.is_connected("changed", pa._on_material_override_changed))
 	assert_true(mmat2.is_connected("changed", pa._on_material_override_changed))
 
 
 	# Delete
-	pa.remove_material_override([1,2])
+	pa.remove_material_override(Vector2i(1,2))
 	assert_eq(1, pa.get_material_overrides().size())
-	pa.remove_material_override([0,1])
+	pa.remove_material_override(Vector2i(0,1))
 	assert_eq(0, pa.get_material_overrides().size())
 
 	assert_false(mmat1.is_connected("changed", pa._on_material_override_changed))
@@ -240,6 +240,16 @@ func test_changed_signals() -> void:
 
 	assert_signal_emit_count(points, "changed", 4)
 	assert_signal_emit_count(points, "update_finished", 2)
+
+
+func test_helpers() -> void:
+	var p_array := SS2D_Point_Array.new()
+	var key1 := p_array.add_point(Vector2(0, 0))
+	var key2 := p_array.add_point(Vector2(1, 1))
+	var key3 := p_array.add_point(Vector2(2, 2))
+
+	assert_eq(p_array.get_edge_keys_for_indices(Vector2i(0, 1)), Vector2i(key1, key2))
+	assert_eq(p_array.get_edge_keys_for_indices(Vector2i(1, 2)), Vector2i(key2, key3))
 
 
 func generate_points() -> Array[Vector2]:

--- a/tests/unit/test_shape_base.gd
+++ b/tests/unit/test_shape_base.gd
@@ -90,9 +90,9 @@ func test_get_meta_material_index_mapping_simple_squareish_shape() -> void:
 	assert_true(mappings_materials.has(shape_material.get_edge_meta_materials(n_up)[0]))
 	assert_true(mappings_materials.has(shape_material.get_edge_meta_materials(n_down)[0]))
 
-	assert_eq(mappings[0].indicies, [0,1,2])
-	assert_eq(mappings[1].indicies, [2,3])
-	assert_eq(mappings[2].indicies, [3,4,5])
+	assert_eq(mappings[0].indicies, PackedInt32Array([0,1,2]))
+	assert_eq(mappings[1].indicies, PackedInt32Array([2,3]))
+	assert_eq(mappings[2].indicies, PackedInt32Array([3,4,5]))
 
 func test_get_meta_material_index_mapping_complex_shape() -> void:
 	var verts: Array[Vector2] = [
@@ -128,13 +128,13 @@ func test_get_meta_material_index_mapping_complex_shape() -> void:
 	assert_true(mappings_materials.has(shape_material.get_edge_meta_materials(n_up)[0]))
 	assert_true(mappings_materials.has(shape_material.get_edge_meta_materials(n_down)[0]))
 
-	assert_eq(mappings[0].indicies, [0,1])
-	assert_eq(mappings[1].indicies, [1,2])
-	assert_eq(mappings[2].indicies, [2,3])
-	assert_eq(mappings[3].indicies, [3,4])
-	assert_eq(mappings[4].indicies, [4,5])
-	assert_eq(mappings[5].indicies, [5,6])
-	assert_eq(mappings[6].indicies, [6,7,8,9,10,11])
+	assert_eq(mappings[0].indicies, PackedInt32Array([0,1]))
+	assert_eq(mappings[1].indicies, PackedInt32Array([1,2]))
+	assert_eq(mappings[2].indicies, PackedInt32Array([2,3]))
+	assert_eq(mappings[3].indicies, PackedInt32Array([3,4]))
+	assert_eq(mappings[4].indicies, PackedInt32Array([4,5]))
+	assert_eq(mappings[5].indicies, PackedInt32Array([5,6]))
+	assert_eq(mappings[6].indicies, PackedInt32Array([6,7,8,9,10,11]))
 
 var offset_params: Array[float] = [1.0, 1.5, 0.5, 0.0, 10.0, -1.0]
 func test_build_edge_with_material_basic_square(offset: float = use_parameters(offset_params)) -> void:

--- a/tests/unit/test_shape_open.gd
+++ b/tests/unit/test_shape_open.gd
@@ -202,7 +202,7 @@ func test_get_edge_meta_materials_many() -> void:
 	assert_eq(s_m.get_all_edge_meta_materials().size(), edge_materials_meta.size())
 	var mappings := SS2D_Shape.get_meta_material_index_mapping(s_m, points, false)
 	assert_eq(mappings.size(), edge_materials_count, "Expecting %s materials" % edge_materials_count)
-	var expected_indicies := [[0, 1, 2], [2, 3], [3, 4], [4, 5]]
+	var expected_indicies := [PackedInt32Array([0, 1, 2]), PackedInt32Array([2, 3]), PackedInt32Array([3, 4]), PackedInt32Array([4, 5])]
 	for i in range(0, mappings.size(), 1):
 		var mapping := mappings[i]
 		assert_eq(expected_indicies[i], mapping.indicies, "Actual indicies match expected?")

--- a/tests/unit/test_tuple.gd
+++ b/tests/unit/test_tuple.gd
@@ -1,50 +1,88 @@
 extends "res://addons/gut/test.gd"
 
-const TUP = preload("res://addons/rmsmartshape/lib/tuple.gd")
-
-
 func test_equality() -> void:
-	var t1 := TUP.create_tuple(5, 3)
-	var t2 := TUP.create_tuple(5, 3)
-	var t3 := TUP.create_tuple(3, 5)
-	var t4 := TUP.create_tuple(3, 7)
-	var t5 := TUP.create_tuple(0, 5)
-	assert_true(TUP.tuples_are_equal(t1, t2))
-	assert_true(TUP.tuples_are_equal(t1, t3))
-	assert_true(TUP.tuples_are_equal(t2, t3))
-	assert_false(TUP.tuples_are_equal(t3, t4))
-	assert_false(TUP.tuples_are_equal(t2, t5))
-
-
-func test_find() -> void:
-	var t1 := TUP.create_tuple(5, 3)
-	var t2 := TUP.create_tuple(5, 3)
-	var t3 := TUP.create_tuple(3, 5)
-	var t4 := TUP.create_tuple(1, 0)
-	var ta := [t1, t2, t3, t4]
-	assert_eq(0, TUP.find_tuple_in_array_of_tuples(ta, t1))
-	assert_eq(0, TUP.find_tuple_in_array_of_tuples(ta, t2))
-	assert_eq(0, TUP.find_tuple_in_array_of_tuples(ta, t3))
-	assert_eq(3, TUP.find_tuple_in_array_of_tuples(ta, t4))
-	assert_eq(-1, TUP.find_tuple_in_array_of_tuples(ta, [7, 8]))
+	var t1 := Vector2i(5, 3)
+	var t2 := Vector2i(5, 3)
+	var t3 := Vector2i(3, 5)
+	var t4 := Vector2i(3, 7)
+	var t5 := Vector2i(0, 5)
+	assert_true(SS2D_IndexTuple.are_equal(t1, t2))
+	assert_true(SS2D_IndexTuple.are_equal(t1, t3))
+	assert_true(SS2D_IndexTuple.are_equal(t2, t3))
+	assert_false(SS2D_IndexTuple.are_equal(t3, t4))
+	assert_false(SS2D_IndexTuple.are_equal(t2, t5))
 
 
 func test_get_other_value() -> void:
-	var t1 := TUP.create_tuple(3, 5)
-	var t2 := TUP.create_tuple(1, 0)
-	assert_eq(5, TUP.get_other_value_from_tuple(t1, 3))
-	assert_eq(3, TUP.get_other_value_from_tuple(t1, 5))
-	assert_eq(1, TUP.get_other_value_from_tuple(t2, 0))
-	assert_eq(0, TUP.get_other_value_from_tuple(t2, 1))
-	assert_eq(-1, TUP.get_other_value_from_tuple(t1, 9))
-	assert_eq(-1, TUP.get_other_value_from_tuple(t2, 9))
+	var t1 := Vector2i(3, 5)
+	var t2 := Vector2i(1, 0)
+	assert_eq(5, SS2D_IndexTuple.get_other_value(t1, 3))
+	assert_eq(3, SS2D_IndexTuple.get_other_value(t1, 5))
+	assert_eq(1, SS2D_IndexTuple.get_other_value(t2, 0))
+	assert_eq(0, SS2D_IndexTuple.get_other_value(t2, 1))
+	assert_eq(-1, SS2D_IndexTuple.get_other_value(t1, 9))
+	assert_eq(-1, SS2D_IndexTuple.get_other_value(t2, 9))
 
 
-func test_is_tuple() -> void:
-	assert_true(TUP.is_tuple([0, 2]))
-	assert_true(TUP.is_tuple([1, 0]))
-	assert_true(TUP.is_tuple([-1000, 1000]))
-	assert_false(TUP.is_tuple([2, 0, 1]))
-	assert_false(TUP.is_tuple([1]))
-	assert_false(TUP.is_tuple("herpderp"))
-	assert_false(TUP.is_tuple(31337))
+func test_dict() -> void:
+	var d := {}
+	var t1 := Vector2i(1, 2)
+	var flipped := SS2D_IndexTuple.flip_elements(t1)
+
+	assert_eq(SS2D_IndexTuple.dict_get(d, t1), null)
+	assert_false(SS2D_IndexTuple.dict_has(d, t1))
+
+	SS2D_IndexTuple.dict_set(d, t1, true)
+
+	assert_eq(d.size(), 1)
+	assert_eq(SS2D_IndexTuple.dict_get(d, t1), true)
+	assert_true(SS2D_IndexTuple.dict_has(d, t1))
+
+	assert_eq(SS2D_IndexTuple.dict_get(d, flipped), true)
+	assert_true(SS2D_IndexTuple.dict_has(d, flipped))
+
+	assert_eq(SS2D_IndexTuple.dict_get_key(d, t1), t1)
+	assert_eq(SS2D_IndexTuple.dict_get_key(d, flipped), t1)
+
+	SS2D_IndexTuple.dict_erase(d, t1)
+	assert_eq(d.size(), 0)
+
+	SS2D_IndexTuple.dict_set(d, t1, true)
+	assert_eq(d.size(), 1)
+	SS2D_IndexTuple.dict_erase(d, flipped)
+	assert_eq(d.size(), 0)
+
+
+func test_flip() -> void:
+	var t := Vector2i(1, 2)
+	assert_eq(SS2D_IndexTuple.flip_elements(t), Vector2i(2, 1))
+
+
+func test_dict_validate() -> void:
+	var d := {}
+	var t := Vector2i(1, 1)
+
+	d[t] = true
+	d[[4, 5]] = true
+
+	SS2D_IndexTuple.dict_validate(d, TYPE_BOOL)
+
+	assert_eq(d.size(), 2)
+	assert_true(d.has(t))
+	assert_true(d.has(Vector2i(4, 5)))
+
+
+func test_array() -> void:
+	var t1 := Vector2i(5, 3)
+	var t2 := Vector2i(3, 7)
+	var arr: Array[Vector2i] = [ t1, t2 ]
+
+	assert_true(SS2D_IndexTuple.array_has(arr, t1))
+	assert_true(SS2D_IndexTuple.array_has(arr, SS2D_IndexTuple.flip_elements(t1)))
+	assert_true(SS2D_IndexTuple.array_has(arr, Vector2(3, 7)))
+	assert_true(SS2D_IndexTuple.array_has(arr, SS2D_IndexTuple.flip_elements(t2)))
+
+	assert_eq(SS2D_IndexTuple.array_find(arr, t1), 0)
+	assert_eq(SS2D_IndexTuple.array_find(arr, SS2D_IndexTuple.flip_elements(t1)), 0)
+	assert_eq(SS2D_IndexTuple.array_find(arr, Vector2(3, 7)), 1)
+	assert_eq(SS2D_IndexTuple.array_find(arr, SS2D_IndexTuple.flip_elements(t2)), 1)


### PR DESCRIPTION
Some code operates on two arbitrary points, e.g. for constraint handling in PointArray. These point tuples have been represented as Array[int] so far.
This PR replaces these usages of Array[int] with Vector2i for several reasons:
  - Less error prone
  - No more problems with typed arrays
  - Better suits the tuple type: there are exactly two int elements, not more, not less, nothing else.

`tuple.gd` contains utility functions for dealing with said index tuples as they have the special equality behavior `T(x, y) <=> T(y, x)`, which needs to be respected when searching in arrays or dictionaries using this tuple type.
Unfortunately, Godot does not allow custom equality and hash functions, so we have to write our own accessor functions for arrays and dictionaries.
This patch improves the previous implementations by
- Refactoring existing functions
- Providing a complete set of accessor functions for arrays and dictionaries
- O(1) access for dictionaries rather than O(n)
- Code cleanup / More straightforward way of working with index tuples.

Finally, as I already mentioned in Discord, I fixed a bug in IndexMap.indicies_to_edges(): The function now correctly operates on the array's values instead of only its indices.

---

This PR introduces quite a bit of refactoring and needs more testing.
Should fix #150 (again) as the problematic parts no longer exist.

@araslanix if you find some time, could you test this PR on your project? You seem to have a project that hits many edge cases, which is insanely valuable here.

I'm also planning to replace various occurences of Array[int] (in non tuple use cases) with PackedInt32Array for performance reasons and also to get rid of as much typed arrays as possible without sacrificing static typing.
Might add this as another commit here or in a new PR, depending on how long it takes.
