### PR TITLE
Add distinct tesselated vertices cache for fast collision

### DIFF
--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -920,7 +920,12 @@ func bake_collision() -> void:
 		generated_points = _generate_collision_points_precise()
 
 	var xform := _collision_polygon_node.get_global_transform().affine_inverse() * get_global_transform()
-	_collision_polygon_node.polygon = xform * generated_points
+	var local_collision_points: PackedVector2Array = xform * generated_points
+
+	if local_collision_points.size() > 1 and local_collision_points[0] == local_collision_points[-1]:
+		local_collision_points.resize(local_collision_points.size() - 1)
+
+	_collision_polygon_node.polygon = local_collision_points
 
 
 func cache_edges() -> void:


### PR DESCRIPTION
I believe the issue originates from SmartShape2D rather than Rapier2D, due to the way collision data is generated. While there is no apparent problem when using the default Godot physics engine, it is inconsistent that the Fast collision generation method produces a duplicated vertex, whereas the Precise method does not.

For the implementation, a straightforward fix would be to exclude the last vertex directly in shape.gd:

```py
func _generate_collision_points_fast() -> PackedVector2Array:
    var tessellated_points: PackedVector2Array = _points.get_tessellated_points()
    return tessellated_points.slice(0, tessellated_points.size() - 1)
```

However, since point_array.gd already caches distinct points, I opted for the approach that avoids reallocating a PackedVector2Array each time the getter is called.

The only subtlety is ensuring the distinct cache initializes properly for the current projects state (without _point_cache_dirty) while requiring no manual interaction with the shape. There is probably a cleaner way to achieve this, so I welcome your feedbacks.

---

fixes #184