### PR TITLE
Collision generation and workflow improvements

### DIFF
--- a/addons/rmsmartshape/collision_gen.gd
+++ b/addons/rmsmartshape/collision_gen.gd
@@ -1,0 +1,253 @@
+extends RefCounted
+class_name SS2D_CollisionGen
+
+# NOTE: Use JOIN_MITER for all transformations because it keeps the corners as they are, which is fast and accurate.
+
+
+## Controls width of generated polygon
+@export var collision_size: float = 32
+
+## Controls offset of generated polygon
+@export var collision_offset: float = 0.0
+
+
+## Generates a collision polygon intended for open polygons.
+## May return the input point array unmodified or a new array.
+func generate_open(points: PackedVector2Array) -> PackedVector2Array:
+	if points.size() <= 2:
+		return PackedVector2Array()
+
+	var offset := collision_offset - collision_size / 2
+
+	if is_equal_approx(offset, 0):
+		return points
+
+	# Geometry2D.offset_polygon() cannot be used to apply collision_offset because it
+	# interprets the given points as closed polygon and may also change the start/end points, which
+	# leads to various issues and is difficult to resolve.
+	points = SS2D_CollisionGen.simple_offset_open_polygon_miter(points, offset)
+
+	return Geometry2D.offset_polyline(points, collision_size / 2, Geometry2D.JOIN_MITER, Geometry2D.END_BUTT).front()
+
+
+## Generates a collision polygon intended for closed polygons.
+## May return the input point array unmodified or a new array.
+func generate_filled(points: PackedVector2Array) -> PackedVector2Array:
+	if points.size() <= 2:
+		return PackedVector2Array()
+
+	if is_equal_approx(collision_offset, 0):
+		return points
+	return Geometry2D.offset_polygon(points, collision_offset, Geometry2D.JOIN_MITER).front()
+
+
+## Generates a hollow collision polygon intended for closed shapes.
+## Use [method generate_collision_points_fast_open] for open shapes.
+func generate_hollow(points: PackedVector2Array) -> PackedVector2Array:
+	# 1) Generate an outer and an inner offset using offset_polygon().
+	# 2) Reverse one array (in this case `outer`) to go along one array, then transition to the other
+	# and return in the opposite direction back to the starting point.
+	# 3) offset_polygon() may change start and end points from the original input, so search for the
+	# closest point in `inner` to the first `outer` point and use that as transition point.
+	#
+	#    0__________1               0/6__________5
+	#    / ________ \  outer          /\________ \
+	#   / /2      3\ \               / /0/6    1\ \
+	# 5/ /1  inner 4\ \2     ->    1/ /5        2\ \4
+	#  \ \          / /             \ \          / /
+	#   \ \0______5/ /               \ \4______3/ /
+	#    \__________/                 \__________/
+	#    4          3                 2          3
+
+	if points.size() <= 2:
+		return PackedVector2Array()
+
+	var outer_offset := collision_offset + collision_size / 2
+	var inner_offset := collision_offset - collision_size / 2
+	var outer: PackedVector2Array
+	var inner: PackedVector2Array = points
+
+	if not is_equal_approx(inner_offset, 0):
+		inner = Geometry2D.offset_polygon(points, inner_offset, Geometry2D.JOIN_MITER).front()
+
+	if not is_equal_approx(outer_offset, 0):
+		outer = Geometry2D.offset_polygon(points, outer_offset, Geometry2D.JOIN_MITER).front()
+	else:
+		# Make a copy so we don't modify the input array which may lead to unexpected behavior, e.g.
+		# when the input is get_point_array().get_tesselated_points().
+		outer = PackedVector2Array(points)
+
+	outer.reverse()
+
+	var closest_idx := 0
+	var closest_dist: float = inner[0].distance_squared_to(outer[0])
+
+	for i in range(1, inner.size()):
+		var dist := inner[i].distance_squared_to(outer[0])
+		if dist < closest_dist:
+			closest_dist = dist
+			closest_idx = i
+
+	outer.push_back(outer[0])
+
+	if closest_idx == 0:
+		outer.append_array(inner)
+	else:
+		outer.append_array(inner.slice(closest_idx))
+		outer.append_array(inner.slice(0, closest_idx))
+		outer.push_back(inner[closest_idx])
+
+	return outer
+
+
+## Legacy method for generating collision polygons.
+## Uses the edge generation algorithm for retrieving the shape outlines.
+## Much slower than other functions (~0.3ms vs ~0.05ms in the collisions.tscn example).
+func generate_legacy(shape: SS2D_Shape) -> PackedVector2Array:
+	var points := PackedVector2Array()
+	var num_points: int = shape._points.get_point_count()
+
+	if num_points < 2:
+		return points
+
+	var is_closed := shape._points.is_shape_closed()
+	var csize: float = 1.0 if is_closed else collision_size
+	var indices := PackedInt32Array(range(num_points))
+	var edge_data := SS2D_IndexMap.new(indices, null)
+	var edge: SS2D_Edge = shape._build_edge_with_material(edge_data, collision_offset - 1.0, csize)
+	shape._weld_quad_array(edge.quads, false)
+
+	if is_closed:
+		var first_quad: SS2D_Quad = edge.quads[0]
+		var last_quad: SS2D_Quad = edge.quads.back()
+		SS2D_Shape.weld_quads(last_quad, first_quad)
+
+	if not edge.quads.is_empty():
+		# Top edge (typically point A unless corner quad)
+		for quad in edge.quads:
+			if quad.corner == SS2D_Quad.CORNER.NONE:
+				points.push_back(quad.pt_a)
+			elif quad.corner == SS2D_Quad.CORNER.OUTER:
+				points.push_back(quad.pt_d)
+			elif quad.corner == SS2D_Quad.CORNER.INNER:
+				pass
+
+		if not is_closed:
+			# Right Edge (point d, the first or final quad will never be a corner)
+			points.push_back(edge.quads[edge.quads.size() - 1].pt_d)
+
+			# Bottom Edge (typically point c)
+			for quad_index in edge.quads.size():
+				var quad: SS2D_Quad = edge.quads[edge.quads.size() - 1 - quad_index]
+				if quad.corner == SS2D_Quad.CORNER.NONE:
+					points.push_back(quad.pt_c)
+				elif quad.corner == SS2D_Quad.CORNER.OUTER:
+					pass
+				elif quad.corner == SS2D_Quad.CORNER.INNER:
+					points.push_back(quad.pt_b)
+
+			# Left Edge (point b)
+			points.push_back(edge.quads[0].pt_b)
+	return points
+
+
+## This is a simple implementation for offseting (inflate/deflate) open polylines but without
+## intersection resolution.
+## Geometry2D.offset_polygon() always interprets the input as closed polygon, which leads to various
+## issues with open shapes, which is the reason why this function exists.
+static func simple_offset_open_polygon_miter(points: PackedVector2Array, offset: float) -> PackedVector2Array:
+	if points.size() < 2 or is_zero_approx(offset):
+		return PackedVector2Array()
+
+	#                   top
+	#            P o_____o_____
+	#              /     |     \
+	#             /      |      \
+	#         b2 o       |d      \
+	#           /  .     |     .  \
+	#          /     .   |   .     \
+	#         /        . o .        \
+	#        /          /b\          \
+	#       /          /   \          \
+	#      /      \   /     \          \
+	#     / ab_orth\ /       \          \
+	#    /          /         \          \
+	#   /          /ab       bc\          \
+	#  /          /             \          \
+	#   .        /               \        .
+	#     .     /                 \     .
+	#       .  /                   \  .
+	#         o                     o
+	#         a                     c
+
+	var new_points := PackedVector2Array()
+	new_points.resize(points.size() * 2)  # Allocate maximum and reduce later.
+
+	var a := points[0]
+	var b := points[1]
+	var ab := b - a
+	var ab_orth := ab.orthogonal().normalized()
+	new_points[0] = points[0] + ab_orth * offset
+	var out_i := 1
+	const miter_threshold := 0.5
+
+	for i in range(1, points.size() - 1):
+		var c := points[i + 1]
+		var bc := c - b
+		var bc_orth := bc.orthogonal().normalized()
+		var dnorm := (ab_orth + bc_orth).normalized()
+		var d := dnorm * offset
+		var miter_denom := maxf(dnorm.dot(ab_orth), 1e-6)
+		var clockwise: bool = (sign(offset) * ab_orth.dot(bc)) < 0
+
+		if clockwise and miter_denom < miter_threshold:
+			# Miter length exceeds threshold -> cap it manually or it will create large peaks.
+			# The cap will be placed `offset` pixels away from b.
+			#
+			# 1) We consider the triangle `b2`, `top` and `P`.
+			# `b2` and `top` are known as well as their directions towards `P` (`ab`, `d_orth`).
+			# `P` is the point where `b2 + t * ab` and `top + u * d_orth` intersect.
+			#
+			#     b2 + t * ab  =  top + u * d_orth  =  P
+			#
+			# We get a linear system with two variables `t` and `u` but we only need to know one.
+			#
+			# 2) Transform equation into matrix form
+			#     t * ab - u * d_orth  =  top - b2
+			#
+			#             A          X  =    B
+			#     ⎛ab.x  -d_orth.x⎞ ⎛t⎞ = ⎛rhs.x⎞
+			#     ⎝ab.y  -d_orth.y⎠ ⎝u⎠   ⎝rhs.y⎠
+			var top := b + d
+			var d_orth := dnorm.orthogonal()
+			var b2 := b + ab_orth * offset
+			var rhs := top - b2
+
+			# 3) Resolve for `u` using Cramer's rule
+			#
+			#      det A_2        ab.x * rhs.y - ab.y * rhs.x
+			# u = --------- = ------------------------------------
+			#       det A      ab.x * -d_orth.y + d_orth.x * ab.y
+			var det_a2 := ab.x * rhs.y - ab.y * rhs.x
+			var det := ab.x * -d_orth.y - -d_orth.x * ab.y
+			var u := det_a2 / det
+
+			# 4) Construct corner points
+			var cap_half_length := u * d_orth  # = P - top
+			new_points[out_i] = top + cap_half_length
+			new_points[out_i + 1] = top - cap_half_length
+			out_i += 2
+		else:
+			new_points[out_i] = b + d / miter_denom
+			out_i += 1
+
+		ab = bc
+		ab_orth = bc_orth
+		a = b
+		b = c
+
+	new_points[out_i] = points[-1] + (points[-1] - points[-2]).orthogonal().normalized() * offset
+	out_i += 1
+	new_points.resize(out_i)
+
+	return new_points

--- a/addons/rmsmartshape/collision_gen.gd.uid
+++ b/addons/rmsmartshape/collision_gen.gd.uid
@@ -1,0 +1,1 @@
+uid://bw6tjof8l1ebn

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -238,13 +238,11 @@ func set_collision_update_mode(value: CollisionUpdateMode) -> void:
 func set_collision_size(s: float) -> void:
 	collision_size = s
 	set_as_dirty()
-	notify_property_list_changed()
 
 
 func set_collision_offset(s: float) -> void:
 	collision_offset = s
 	set_as_dirty()
-	notify_property_list_changed()
 
 
 ## Deprecated. Use get_point_array().set_from_curve() instead.

--- a/addons/rmsmartshape/shapes/shape.gd
+++ b/addons/rmsmartshape/shapes/shape.gd
@@ -149,12 +149,10 @@ var tessellation_tolerence: float = 6.0 :
 @export var collision_update_mode := CollisionUpdateMode.Editor : set = set_collision_update_mode
 
 ## Controls size of generated polygon for CollisionPolygon2D.
-@export_range(0.0, 64.0, 1.0, "or_greater")
-var collision_size: float = 32 : set = set_collision_size
+@export var collision_size: float = 32 : set = set_collision_size
 
 ## Controls offset of generated polygon for CollisionPolygon2D.
-@export_range(-64.0, 64.0, 1.0, "or_greater", "or_lesser")
-var collision_offset: float = 0.0 : set = set_collision_offset
+@export var collision_offset: float = 0.0 : set = set_collision_offset
 
 ## NodePath to CollisionPolygon2D node for which polygon data will be generated.
 @export_node_path("CollisionPolygon2D") var collision_polygon_node_path: NodePath : set = set_collision_polygon_node_path

--- a/addons/rmsmartshape/strings.gd
+++ b/addons/rmsmartshape/strings.gd
@@ -9,9 +9,10 @@ const EN_TOOLTIP_CUT_EDGE := "Cut Edge Tool\nRemoves the edge between vertices, 
 const EN_TOOLTIP_FREEHAND := "Freehand Tool\nHold LMB: Add vertices along the drag line.\nControl+LMB: remove vertices inside the circle while dragging.\nShift+Mousewheel: Change circle size for drawing.\nShift+Control+Mousewheel: Change circle size for eraser."
 const EN_TOOLTIP_PIVOT := "Set Pivot Tool\nSets the origin of the shape"
 const EN_TOOLTIP_CENTER_PIVOT := "Center Pivot\nSets the origin to the centroid of the shape"
-const EN_TOOLTIP_COLLISION := "Collision Tool\nAdds a static body parent and collision polygon sibling\nUse this to auto-generate collision nodes"
+const EN_TOOLTIP_COLLISION := "Collision Tool\nAdds a CollisionPolygon2D and assigns it to the shape.\nUse this to auto-setup shape collisions."
 const EN_TOOLTIP_SNAP := "Snapping Options"
 const EN_TOOLTIP_MORE_OPTIONS := "More Options"
 
 const EN_OPTIONS_DEFER_MESH_UPDATES := "Defer Mesh Updates"
 const EN_OPTIONS_CHECK_VERSION := "Perform Version Check"
+const EN_OPTIONS_COLLISIONS := "Collision Generation Options"

--- a/addons/rmsmartshape/tools/collision_tool.gd
+++ b/addons/rmsmartshape/tools/collision_tool.gd
@@ -1,0 +1,107 @@
+extends SS2D_EditorTool
+class_name SS2D_CollisionEditorTool
+
+const ICON_COLLISION: Texture2D = preload("res://addons/rmsmartshape/assets/icon_collision_polygon_2d.svg")
+const CONFIG_KEY = "collision_container_path"
+
+var _collision_container_path: String
+var _options_dialog := OptionsDialog.new()
+
+
+# NOTE: Could be a scene, but it's rather simple and has static typing without polluting the "Add node" dialog.
+class OptionsDialog:
+	extends AcceptDialog
+
+	var line_edit: LineEdit
+
+	func _init() -> void:
+		title = SS2D_Strings.EN_OPTIONS_COLLISIONS
+		exclusive = false  # Prevent error when opening node selection dialog
+
+		var content := VBoxContainer.new()
+		add_child(content)
+
+		var label := Label.new()
+		label.text = """
+		Enter a node path, a group name or a scene unique name.
+		The first node found is used as parent for collision polygons generated using the Collision Tool.
+		If empty, the collision polygon is created as sibling to the shape node.
+
+		For example: %StaticBody2D, %level/StaticBody2D, collision_body_group, etc.
+		""".dedent().strip_edges()
+		content.add_child(label)
+
+		line_edit = LineEdit.new()
+		line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		register_text_enter(line_edit)
+
+		var select_node := Button.new()
+		select_node.text = "Select"
+		select_node.pressed.connect(EditorInterface.popup_node_selector.bind(_on_node_selected))
+
+		var hbox := HBoxContainer.new()
+		hbox.add_child(line_edit)
+		hbox.add_child(select_node)
+		content.add_child(hbox)
+
+	func _on_node_selected(path: NodePath) -> void:
+		if not visible:  # Dialog could be closed while node selection is still open
+			return
+
+		if not path.is_empty():
+			var node := get_tree().edited_scene_root.get_node(path)
+
+			if node.unique_name_in_owner:
+				line_edit.text = "%" + node.name
+			else:
+				line_edit.text = path
+
+	func set_selected_node_path(path: NodePath) -> void:
+		line_edit.text = path
+
+	func get_selected_node_path() -> NodePath:
+		return NodePath(line_edit.text)
+
+
+func load_config(conf: ConfigFile) -> void:
+	_collision_container_path = conf.get_value(CONFIG_OPTIONS_SECTION, CONFIG_KEY, "")
+
+
+func save_config(conf: ConfigFile) -> void:
+	conf.set_value(CONFIG_OPTIONS_SECTION, CONFIG_KEY, _collision_container_path)
+
+
+func register(editor_plugin: EditorPlugin) -> void:
+	super.register(editor_plugin)
+	create_options_item(SS2D_Strings.EN_OPTIONS_COLLISIONS, _on_options_clicked)
+	create_tool_button(ICON_COLLISION, SS2D_Strings.EN_TOOLTIP_COLLISION, false).pressed.connect(_on_tool_clicked)
+
+	_options_dialog.confirmed.connect(_on_options_confirmed)
+	get_plugin().add_child(_options_dialog)
+
+
+func _on_tool_clicked() -> void:
+	if get_shape():
+		perform_action(SS2D_ActionAddCollisionNodes.new(get_shape(), _get_collision_container_node()))
+
+
+func _on_options_clicked() -> void:
+	_options_dialog.set_selected_node_path(_collision_container_path)
+	_options_dialog.popup_centered()
+
+
+func _on_options_confirmed() -> void:
+	_collision_container_path = _options_dialog.get_selected_node_path()
+
+
+func _get_collision_container_node() -> Node:
+	if not _collision_container_path:
+		return null
+
+	var tree := get_plugin().get_tree()
+	var node := tree.edited_scene_root.get_node_or_null(_collision_container_path)
+
+	if node:
+		return node
+
+	return tree.get_first_node_in_group(_collision_container_path)

--- a/addons/rmsmartshape/tools/collision_tool.gd.uid
+++ b/addons/rmsmartshape/tools/collision_tool.gd.uid
@@ -1,0 +1,1 @@
+uid://baklv7u5sw7rp

--- a/addons/rmsmartshape/tools/editor_tool.gd
+++ b/addons/rmsmartshape/tools/editor_tool.gd
@@ -1,0 +1,74 @@
+extends RefCounted
+class_name SS2D_EditorTool
+
+const CONFIG_OPTIONS_SECTION = "options"
+
+var _editor_plugin: SS2D_Plugin
+var _toolbar: Control
+var _options_menu: PopupMenu
+var _options_entries := {}  ## Dict[int, Callable]
+
+
+func load_config(_conf: ConfigFile) -> void:
+	pass
+
+
+func save_config(_conf: ConfigFile) -> void:
+	pass
+
+
+## Initialize the tool and register UI controls.
+## Derived classes must call the base implementation!
+func register(editor_plugin: EditorPlugin) -> void:
+	_editor_plugin = editor_plugin
+
+	# TODO: Add an abstraction with tighter interface for the toolbar, e.g. SS2D_Toolbar
+	_toolbar = _editor_plugin.tb_hb
+
+	_options_menu = _editor_plugin.tb_options_popup
+	_options_menu.index_pressed.connect(_on_options_index_pressed_dispatch)
+
+
+## Create a tool button in the toolbar.
+func create_tool_button(icon: Texture2D, tooltip: String, toggle: bool = true) -> Button:
+	return _editor_plugin.create_tool_button(icon, tooltip, toggle)
+
+
+func perform_action(action: SS2D_Action) -> void:
+	_editor_plugin.perform_action(action)
+
+
+func create_options_item(label: String, callback: Callable) -> void:
+	_options_menu.add_item(label)
+	_options_entries[_options_menu.item_count - 1] = callback
+
+
+func get_options_menu() -> PopupMenu:
+	return _options_menu
+
+
+func get_toolbar() -> Control:
+	return _toolbar
+
+
+func get_plugin() -> EditorPlugin:
+	return _editor_plugin
+
+
+func get_shape() -> SS2D_Shape:
+	return _editor_plugin.shape
+
+
+## Adds the dialog node to the tree and displays it.
+## Connects to `confirmed` and `canceled` signals to `queue_free()` it when closed.
+func show_oneshot_dialog(dialog: AcceptDialog) -> void:
+	dialog.confirmed.connect(dialog.queue_free)
+	dialog.canceled.connect(dialog.queue_free)
+	_editor_plugin.add_child(dialog)
+	dialog.popup_centered()
+
+
+func _on_options_index_pressed_dispatch(idx: int) -> void:
+	var callback: Callable = _options_entries.get(idx)
+	if callback:
+		callback.call()

--- a/addons/rmsmartshape/tools/editor_tool.gd.uid
+++ b/addons/rmsmartshape/tools/editor_tool.gd.uid
@@ -1,0 +1,1 @@
+uid://btoqcxgi2t35b

--- a/examples/collisions.tscn
+++ b/examples/collisions.tscn
@@ -1,0 +1,619 @@
+[gd_scene load_steps=63 format=4 uid="uid://dkx5maxjgcjov"]
+
+[ext_resource type="Script" uid="uid://dhdc4b8yddyej" path="res://addons/rmsmartshape/shapes/shape.gd" id="1_bgypd"]
+[ext_resource type="Script" uid="uid://byp4h2084wgn2" path="res://addons/rmsmartshape/vertex_properties.gd" id="2_a7ka1"]
+[ext_resource type="Script" uid="uid://bwcf4pjgprn0k" path="res://addons/rmsmartshape/shapes/point.gd" id="3_isrss"]
+[ext_resource type="Script" uid="uid://bo5f7qe27jfje" path="res://addons/rmsmartshape/shapes/point_array.gd" id="4_j8hj2"]
+[ext_resource type="Script" uid="uid://llobjh5hvry" path="res://addons/rmsmartshape/shapes/mesh.gd" id="5_b3my5"]
+[ext_resource type="Texture2D" uid="uid://8l501jrnaqt8" path="res://icon.png" id="6_yj1kx"]
+[ext_resource type="Script" uid="uid://0lhxan4cqrc1" path="res://addons/rmsmartshape/materials/edge_material_metadata.gd" id="7_f6ybp"]
+[ext_resource type="Script" uid="uid://nc5bfedvnpgm" path="res://addons/rmsmartshape/materials/shape_material.gd" id="8_q32v1"]
+[ext_resource type="Script" uid="uid://d0xjijisx1woh" path="res://addons/rmsmartshape/materials/edge_material.gd" id="9_isrss"]
+[ext_resource type="Script" uid="uid://d218yx0d1ilsn" path="res://addons/rmsmartshape/normal_range.gd" id="10_j8hj2"]
+
+[sub_resource type="Resource" id="Resource_isrss"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_iqabp"]
+script = ExtResource("3_isrss")
+position = Vector2(0, 0)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_isrss")
+
+[sub_resource type="Resource" id="Resource_j8hj2"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_xv4bw"]
+script = ExtResource("3_isrss")
+position = Vector2(100, 0)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_j8hj2")
+
+[sub_resource type="Resource" id="Resource_b3my5"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_r1arj"]
+script = ExtResource("3_isrss")
+position = Vector2(100, 100)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_b3my5")
+
+[sub_resource type="Resource" id="Resource_yj1kx"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_x17xs"]
+script = ExtResource("3_isrss")
+position = Vector2(0, 100)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_yj1kx")
+
+[sub_resource type="Resource" id="Resource_rg4d3"]
+script = ExtResource("2_a7ka1")
+texture_idx = 6
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_ycluc"]
+script = ExtResource("3_isrss")
+position = Vector2(210, 50)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_rg4d3")
+
+[sub_resource type="Resource" id="Resource_ciy6r"]
+script = ExtResource("2_a7ka1")
+texture_idx = 1
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_v5b6r"]
+script = ExtResource("3_isrss")
+position = Vector2(50, 130)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_ciy6r")
+
+[sub_resource type="Resource" id="Resource_f6ybp"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_itfev"]
+script = ExtResource("3_isrss")
+position = Vector2(80, 50)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_f6ybp")
+
+[sub_resource type="Resource" id="Resource_ms6jj"]
+script = ExtResource("3_isrss")
+position = Vector2(50, 130)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_ciy6r")
+
+[sub_resource type="Resource" id="Resource_isa7x"]
+script = ExtResource("4_j8hj2")
+_points = {
+0: SubResource("Resource_iqabp"),
+1: SubResource("Resource_xv4bw"),
+2: SubResource("Resource_r1arj"),
+3: SubResource("Resource_x17xs"),
+6: SubResource("Resource_ycluc"),
+7: SubResource("Resource_v5b6r"),
+8: SubResource("Resource_itfev"),
+9: SubResource("Resource_ms6jj")
+}
+_point_order = PackedInt32Array(7, 3, 8, 0, 1, 6, 2, 9)
+_constraints = {
+Vector2i(7, 9): 15
+}
+_next_key = 10
+_material_overrides = {}
+tessellation_stages = 3
+tessellation_tolerance = 6.0
+curve_bake_interval = 20.0
+
+[sub_resource type="ArrayMesh" id="ArrayMesh_isrss"]
+_surfaces = [{
+"aabb": AABB(0, 0, 0, 210, 130, 1e-05),
+"attribute_data": PackedByteArray("/////wAAoD8AAEg/AACgPwAASD//////AAAAAAAAAAAAAAAAAAAAAP////8AAMg/AAAAAAAAyD8AAAAA/////wAAUkAAAEg/AABSQAAASD//////AADIPwAAyD8AAMg/AADIP/////8AAAAAAADIPwAAAAAAAMg//////wAASD8AAAJAAABIPwAAAkA="),
+"format": 34359742527,
+"index_count": 18,
+"index_data": PackedByteArray("AAABAAIAAgADAAQAAAACAAQABQAAAAQABAAGAAYABgAFAAQA"),
+"primitive": 3,
+"uv_scale": Vector4(0, 0, 0, 0),
+"vertex_count": 7,
+"vertex_data": PackedByteArray("AACgQgAASEIAAAAAAAAAAAAAAAAAAAAAAADIQgAAAAAAAAAAAABSQwAASEIAAAAAAADIQgAAyEIAAAAAAAAAAAAAyEIAAAAAAABIQgAAAkMAAAAA/////////7//////////v/////////+//////////7//////////v/////////+//////////78=")
+}]
+
+[sub_resource type="Resource" id="Resource_q32v1"]
+script = ExtResource("5_b3my5")
+texture = ExtResource("6_yj1kx")
+mesh = SubResource("ArrayMesh_isrss")
+z_index = -10
+z_as_relative = true
+show_behind_parent = false
+force_no_tiling = false
+
+[sub_resource type="Resource" id="Resource_ym61l"]
+script = ExtResource("8_q32v1")
+_edge_meta_materials = Array[ExtResource("7_f6ybp")]([])
+fill_textures = Array[Texture2D]([ExtResource("6_yj1kx")])
+fill_texture_z_index = -10
+fill_texture_show_behind_parent = false
+fill_texture_scale = 1.0
+fill_texture_absolute_position = false
+fill_texture_absolute_rotation = false
+fill_texture_offset = Vector2(0, 0)
+fill_texture_angle_offset = 0.0
+fill_mesh_offset = 0.0
+render_offset = 0.0
+
+[sub_resource type="ArrayMesh" id="ArrayMesh_rilut"]
+_surfaces = [{
+"aabb": AABB(0, 0, 0, 210, 130, 1e-05),
+"attribute_data": PackedByteArray("/////wAAoD8AAEg/AACgPwAASD//////AAAAAAAAAAAAAAAAAAAAAP////8AAMg/AAAAAAAAyD8AAAAA/////wAAUkAAAEg/AABSQAAASD//////AADIPwAAyD8AAMg/AADIP/////8AAAAAAADIPwAAAAAAAMg//////wAASD8AAAJAAABIPwAAAkA="),
+"format": 34359742527,
+"index_count": 18,
+"index_data": PackedByteArray("AAABAAIAAgADAAQAAAACAAQABQAAAAQABAAGAAYABgAFAAQA"),
+"primitive": 3,
+"uv_scale": Vector4(0, 0, 0, 0),
+"vertex_count": 7,
+"vertex_data": PackedByteArray("AACgQgAASEIAAAAAAAAAAAAAAAAAAAAAAADIQgAAAAAAAAAAAABSQwAASEIAAAAAAADIQgAAyEIAAAAAAAAAAAAAyEIAAAAAAABIQgAAAkMAAAAA/////////7//////////v/////////+//////////7//////////v/////////+//////////78=")
+}]
+
+[sub_resource type="Resource" id="Resource_ouyma"]
+script = ExtResource("5_b3my5")
+texture = ExtResource("6_yj1kx")
+mesh = SubResource("ArrayMesh_rilut")
+z_index = -10
+z_as_relative = true
+show_behind_parent = false
+force_no_tiling = false
+
+[sub_resource type="ArrayMesh" id="ArrayMesh_28aev"]
+_surfaces = [{
+"aabb": AABB(0, 0, 0, 210, 130, 1e-05),
+"attribute_data": PackedByteArray("/////wAAoD8AAEg/AACgPwAASD//////AAAAAAAAAAAAAAAAAAAAAP////8AAMg/AAAAAAAAyD8AAAAA/////wAAUkAAAEg/AABSQAAASD//////AADIPwAAyD8AAMg/AADIP/////8AAAAAAADIPwAAAAAAAMg//////wAASD8AAAJAAABIPwAAAkA="),
+"format": 34359742527,
+"index_count": 18,
+"index_data": PackedByteArray("AAABAAIAAgADAAQAAAACAAQABQAAAAQABAAGAAYABgAFAAQA"),
+"primitive": 3,
+"uv_scale": Vector4(0, 0, 0, 0),
+"vertex_count": 7,
+"vertex_data": PackedByteArray("AACgQgAASEIAAAAAAAAAAAAAAAAAAAAAAADIQgAAAAAAAAAAAABSQwAASEIAAAAAAADIQgAAyEIAAAAAAAAAAAAAyEIAAAAAAABIQgAAAkMAAAAA/////////7//////////v/////////+//////////7//////////v/////////+//////////78=")
+}]
+
+[sub_resource type="Resource" id="Resource_gmc7f"]
+script = ExtResource("5_b3my5")
+texture = ExtResource("6_yj1kx")
+mesh = SubResource("ArrayMesh_28aev")
+z_index = -10
+z_as_relative = true
+show_behind_parent = false
+force_no_tiling = false
+
+[sub_resource type="Resource" id="Resource_2hfpi"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_w4570"]
+script = ExtResource("3_isrss")
+position = Vector2(0, 0)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_2hfpi")
+
+[sub_resource type="Resource" id="Resource_cqjfy"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_3bnhh"]
+script = ExtResource("3_isrss")
+position = Vector2(100, 0)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_cqjfy")
+
+[sub_resource type="Resource" id="Resource_wg23u"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_lawjw"]
+script = ExtResource("3_isrss")
+position = Vector2(140, 90)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_wg23u")
+
+[sub_resource type="Resource" id="Resource_ge06c"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_vpdol"]
+script = ExtResource("3_isrss")
+position = Vector2(0, 100)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_ge06c")
+
+[sub_resource type="Resource" id="Resource_cc3lo"]
+script = ExtResource("2_a7ka1")
+texture_idx = 6
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_bw34n"]
+script = ExtResource("3_isrss")
+position = Vector2(210, 50)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_cc3lo")
+
+[sub_resource type="Resource" id="Resource_urb62"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_yhdfm"]
+script = ExtResource("3_isrss")
+position = Vector2(100, 100)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_urb62")
+
+[sub_resource type="Resource" id="Resource_momqr"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_bkhmw"]
+script = ExtResource("3_isrss")
+position = Vector2(80, 50)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_momqr")
+
+[sub_resource type="Resource" id="Resource_tydxg"]
+script = ExtResource("2_a7ka1")
+texture_idx = 0
+flip = false
+width = 1.0
+
+[sub_resource type="Resource" id="Resource_cbecy"]
+script = ExtResource("3_isrss")
+position = Vector2(50, 130)
+point_in = Vector2(0, 0)
+point_out = Vector2(0, 0)
+properties = SubResource("Resource_tydxg")
+
+[sub_resource type="Resource" id="Resource_hff64"]
+script = ExtResource("4_j8hj2")
+_points = {
+0: SubResource("Resource_w4570"),
+1: SubResource("Resource_3bnhh"),
+2: SubResource("Resource_lawjw"),
+3: SubResource("Resource_vpdol"),
+6: SubResource("Resource_bw34n"),
+7: SubResource("Resource_yhdfm"),
+8: SubResource("Resource_bkhmw"),
+10: SubResource("Resource_cbecy")
+}
+_point_order = PackedInt32Array(7, 10, 3, 8, 0, 1, 6, 2)
+_constraints = {}
+_next_key = 11
+_material_overrides = {}
+tessellation_stages = 3
+tessellation_tolerance = 6.0
+curve_bake_interval = 20.0
+
+[sub_resource type="ArrayMesh" id="ArrayMesh_j8hj2"]
+_surfaces = [{
+"aabb": AABB(-2.12, -4, 0, 214.105, 138, 1e-05),
+"attribute_data": PackedByteArray("/////wAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAgD8AAAAAAACAP/////8YuulAAACAPxi66UAAAIA//////xi66UAAAAAAGLrpQAAAAAD/////GLppQQAAgD8YumlBAACAP/////8YumlBAAAAABi6aUEAAAAA/////xi6aUEAAAAAGLppQQAAAAD/////GLppQQAAgD8YumlBAACAP/////+AZdNBAACAP4Bl00EAAIA//////4Bl00EAAAAAgGXTQQAAAAD/////gGXTQQAAAACAZdNBAAAAAP////+AZdNBAACAP4Bl00EAAIA///////r2GEIAAIA/+vYYQgAAgD//////+vYYQgAAAAD69hhCAAAAAP/////69hhCAAAAAPr2GEIAAAAA//////r2GEIAAIA/+vYYQgAAgD//////MhFLQgAAgD8yEUtCAACAP/////8yEUtCAAAAADIRS0IAAAAA/////5bNg0IAAIA/ls2DQgAAgD//////ls2DQgAAAACWzYNCAAAAAP////+WzYNCAAAAAJbNg0IAAAAA/////5bNg0IAAIA/ls2DQgAAgD//////AACYQgAAgD8AAJhCAACAP/////8AAJhCAAAAAAAAmEIAAAAA"),
+"format": 34359742527,
+"index_count": 42,
+"index_data": PackedByteArray("AAABAAIAAAACAAMAAwACAAQAAwAEAAUABgAHAAgABgAIAAkACgALAAwACgAMAA0ADgAPABAADgAQABEAEQAQABIAEQASABMAFAAVABYAFAAWABcA"),
+"primitive": 3,
+"uv_scale": Vector4(0, 0, 0, 0),
+"vertex_count": 24,
+"vertex_data": PackedByteArray("sB3MQiXczkIAAAAAUOLDQtsjwUIAAAAAAABIQgAA/EIAAAAAAABIQgAABkMAAAAA/rUDQNsjwUIAAAAA/rUDwCXczkIAAAAAA64HwE03wUIAAAAAA64HQLPIzkIAAAAAcD2kQmeRVUIAAAAAkMKbQpluOkIAAAAAkMKbQmeRVUIAAAAAcD2kQpluOkIAAAAAA64HQGoWWcAAAAAAA64HwGoWWUAAAAAAAAAAAAAAgMAAAAAAAAAAAAAAgEAAAAAAcE7GQpoyekAAAAAAkLHJQpoyesAAAAAARFhQQ9yQVkIAAAAAvKdTQyRvOUIAAAAADPxTQ1PkVUIAAAAA9ANQQ60bOkIAAAAA9AMKQ9cNrUIAAAAADPwNQynyukIAAAAA/3//f5UwtSf/f/9/rzCnJ/9//38oAZRA/3//fxUBikD/f/9/cy+5V/9//39bL61X/3//f8TOnVj/f/9/xM6dWP9//3/Ezp1Y/3//f8TOnVj/f/9/OjGdWP9//386MZ1Y/3//fzoxnVj/f/9/OjGdWP9//3/k/w1A/3//f+H/DkD/f/9/IumRNP9//38i6ZE0/3//fwvYBiz/f/9/DdgGLP9//3+LLroo/3//f4suuij/f/9/iy66KP9//3+LLroo")
+}]
+
+[sub_resource type="Gradient" id="Gradient_b3my5"]
+offsets = PackedFloat32Array(1)
+colors = PackedColorArray(1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_yj1kx"]
+gradient = SubResource("Gradient_b3my5")
+width = 8
+height = 8
+
+[sub_resource type="Resource" id="Resource_rilut"]
+script = ExtResource("5_b3my5")
+texture = SubResource("GradientTexture2D_yj1kx")
+mesh = SubResource("ArrayMesh_j8hj2")
+z_index = 0
+z_as_relative = true
+show_behind_parent = false
+force_no_tiling = false
+
+[sub_resource type="Resource" id="Resource_rxnt7"]
+script = ExtResource("9_isrss")
+textures = Array[Texture2D]([SubResource("GradientTexture2D_yj1kx")])
+textures_corner_outer = Array[Texture2D]([])
+textures_corner_inner = Array[Texture2D]([])
+textures_taper_left = Array[Texture2D]([])
+textures_taper_right = Array[Texture2D]([])
+textures_taper_corner_left = Array[Texture2D]([])
+textures_taper_corner_right = Array[Texture2D]([])
+randomize_texture = false
+use_corner_texture = false
+use_taper_texture = false
+fit_mode = 0
+metadata/_custom_type_script = "uid://d0xjijisx1woh"
+
+[sub_resource type="Resource" id="Resource_c6umj"]
+script = ExtResource("10_j8hj2")
+begin = 0.0
+distance = 360.0
+edgeRendering = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_w40a3"]
+script = ExtResource("7_f6ybp")
+edge_material = SubResource("Resource_rxnt7")
+normal_range = SubResource("Resource_c6umj")
+weld = true
+taper_sharp_corners = true
+render = true
+z_index = 0
+z_as_relative = true
+offset = 0.0
+metadata/_custom_type_script = "uid://0lhxan4cqrc1"
+
+[sub_resource type="Resource" id="Resource_6qbm5"]
+script = ExtResource("8_q32v1")
+_edge_meta_materials = Array[ExtResource("7_f6ybp")]([SubResource("Resource_w40a3")])
+fill_textures = Array[Texture2D]([])
+fill_texture_z_index = -10
+fill_texture_show_behind_parent = false
+fill_texture_scale = 1.0
+fill_texture_absolute_position = false
+fill_texture_absolute_rotation = false
+fill_texture_offset = Vector2(0, 0)
+fill_texture_angle_offset = 0.0
+fill_mesh_offset = 0.0
+render_offset = 0.0
+metadata/_custom_type_script = "uid://nc5bfedvnpgm"
+
+[sub_resource type="ArrayMesh" id="ArrayMesh_ym61l"]
+_surfaces = [{
+"aabb": AABB(-2.12, -4, 0, 214.105, 138, 1e-05),
+"attribute_data": PackedByteArray("/////wAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAgD8AAAAAAACAP/////8YuulAAACAPxi66UAAAIA//////xi66UAAAAAAGLrpQAAAAAD/////GLppQQAAgD8YumlBAACAP/////8YumlBAAAAABi6aUEAAAAA/////xi6aUEAAAAAGLppQQAAAAD/////GLppQQAAgD8YumlBAACAP/////+AZdNBAACAP4Bl00EAAIA//////4Bl00EAAAAAgGXTQQAAAAD/////gGXTQQAAAACAZdNBAAAAAP////+AZdNBAACAP4Bl00EAAIA///////r2GEIAAIA/+vYYQgAAgD//////+vYYQgAAAAD69hhCAAAAAP/////69hhCAAAAAPr2GEIAAAAA//////r2GEIAAIA/+vYYQgAAgD//////MhFLQgAAgD8yEUtCAACAP/////8yEUtCAAAAADIRS0IAAAAA/////5bNg0IAAIA/ls2DQgAAgD//////ls2DQgAAAACWzYNCAAAAAP////+WzYNCAAAAAJbNg0IAAAAA/////5bNg0IAAIA/ls2DQgAAgD//////AACYQgAAgD8AAJhCAACAP/////8AAJhCAAAAAAAAmEIAAAAA"),
+"format": 34359742527,
+"index_count": 42,
+"index_data": PackedByteArray("AAABAAIAAAACAAMAAwACAAQAAwAEAAUABgAHAAgABgAIAAkACgALAAwACgAMAA0ADgAPABAADgAQABEAEQAQABIAEQASABMAFAAVABYAFAAWABcA"),
+"primitive": 3,
+"uv_scale": Vector4(0, 0, 0, 0),
+"vertex_count": 24,
+"vertex_data": PackedByteArray("sB3MQiXczkIAAAAAUOLDQtsjwUIAAAAAAABIQgAA/EIAAAAAAABIQgAABkMAAAAA/rUDQNsjwUIAAAAA/rUDwCXczkIAAAAAA64HwE03wUIAAAAAA64HQLPIzkIAAAAAcD2kQmeRVUIAAAAAkMKbQpluOkIAAAAAkMKbQmeRVUIAAAAAcD2kQpluOkIAAAAAA64HQGoWWcAAAAAAA64HwGoWWUAAAAAAAAAAAAAAgMAAAAAAAAAAAAAAgEAAAAAAcE7GQpoyekAAAAAAkLHJQpoyesAAAAAARFhQQ9yQVkIAAAAAvKdTQyRvOUIAAAAADPxTQ1PkVUIAAAAA9ANQQ60bOkIAAAAA9AMKQ9cNrUIAAAAADPwNQynyukIAAAAA/3//f5UwtSf/f/9/rzCnJ/9//38oAZRA/3//fxUBikD/f/9/cy+5V/9//39bL61X/3//f8TOnVj/f/9/xM6dWP9//3/Ezp1Y/3//f8TOnVj/f/9/OjGdWP9//386MZ1Y/3//fzoxnVj/f/9/OjGdWP9//3/k/w1A/3//f+H/DkD/f/9/IumRNP9//38i6ZE0/3//fwvYBiz/f/9/DdgGLP9//3+LLroo/3//f4suuij/f/9/iy66KP9//3+LLroo")
+}]
+
+[sub_resource type="Resource" id="Resource_fy8q1"]
+script = ExtResource("5_b3my5")
+texture = SubResource("GradientTexture2D_yj1kx")
+mesh = SubResource("ArrayMesh_ym61l")
+z_index = 0
+z_as_relative = true
+show_behind_parent = false
+force_no_tiling = false
+
+[sub_resource type="ArrayMesh" id="ArrayMesh_rpin6"]
+_surfaces = [{
+"aabb": AABB(-2.12, -4, 0, 214.105, 138, 1e-05),
+"attribute_data": PackedByteArray("/////wAAAAAAAAAAAAAAAAAAAAD/////AAAAAAAAgD8AAAAAAACAP/////8YuulAAACAPxi66UAAAIA//////xi66UAAAAAAGLrpQAAAAAD/////GLppQQAAgD8YumlBAACAP/////8YumlBAAAAABi6aUEAAAAA/////xi6aUEAAAAAGLppQQAAAAD/////GLppQQAAgD8YumlBAACAP/////+AZdNBAACAP4Bl00EAAIA//////4Bl00EAAAAAgGXTQQAAAAD/////gGXTQQAAAACAZdNBAAAAAP////+AZdNBAACAP4Bl00EAAIA///////r2GEIAAIA/+vYYQgAAgD//////+vYYQgAAAAD69hhCAAAAAP/////69hhCAAAAAPr2GEIAAAAA//////r2GEIAAIA/+vYYQgAAgD//////MhFLQgAAgD8yEUtCAACAP/////8yEUtCAAAAADIRS0IAAAAA/////5bNg0IAAIA/ls2DQgAAgD//////ls2DQgAAAACWzYNCAAAAAP////+WzYNCAAAAAJbNg0IAAAAA/////5bNg0IAAIA/ls2DQgAAgD//////AACYQgAAgD8AAJhCAACAP/////8AAJhCAAAAAAAAmEIAAAAA"),
+"format": 34359742527,
+"index_count": 42,
+"index_data": PackedByteArray("AAABAAIAAAACAAMAAwACAAQAAwAEAAUABgAHAAgABgAIAAkACgALAAwACgAMAA0ADgAPABAADgAQABEAEQAQABIAEQASABMAFAAVABYAFAAWABcA"),
+"primitive": 3,
+"uv_scale": Vector4(0, 0, 0, 0),
+"vertex_count": 24,
+"vertex_data": PackedByteArray("sB3MQiXczkIAAAAAUOLDQtsjwUIAAAAAAABIQgAA/EIAAAAAAABIQgAABkMAAAAA/rUDQNsjwUIAAAAA/rUDwCXczkIAAAAAA64HwE03wUIAAAAAA64HQLPIzkIAAAAAcD2kQmeRVUIAAAAAkMKbQpluOkIAAAAAkMKbQmeRVUIAAAAAcD2kQpluOkIAAAAAA64HQGoWWcAAAAAAA64HwGoWWUAAAAAAAAAAAAAAgMAAAAAAAAAAAAAAgEAAAAAAcE7GQpoyekAAAAAAkLHJQpoyesAAAAAARFhQQ9yQVkIAAAAAvKdTQyRvOUIAAAAADPxTQ1PkVUIAAAAA9ANQQ60bOkIAAAAA9AMKQ9cNrUIAAAAADPwNQynyukIAAAAA/3//f5UwtSf/f/9/rzCnJ/9//38oAZRA/3//fxUBikD/f/9/cy+5V/9//39bL61X/3//f8TOnVj/f/9/xM6dWP9//3/Ezp1Y/3//f8TOnVj/f/9/OjGdWP9//386MZ1Y/3//fzoxnVj/f/9/OjGdWP9//3/k/w1A/3//f+H/DkD/f/9/IumRNP9//38i6ZE0/3//fwvYBiz/f/9/DdgGLP9//3+LLroo/3//f4suuij/f/9/iy66KP9//3+LLroo")
+}]
+
+[sub_resource type="Resource" id="Resource_tax1t"]
+script = ExtResource("5_b3my5")
+texture = SubResource("GradientTexture2D_yj1kx")
+mesh = SubResource("ArrayMesh_rpin6")
+z_index = 0
+z_as_relative = true
+show_behind_parent = false
+force_no_tiling = false
+
+[node name="test_collisions" type="Node2D"]
+position = Vector2(230, 190)
+
+[node name="Label" type="Label" parent="."]
+offset_left = -30.0
+offset_top = -180.0
+offset_right = 621.0
+offset_bottom = -105.0
+text = "Demonstration of different collision generation methods with the same parameters.
+Collision Offset = 20
+Collision Size = 10"
+metadata/_edit_use_anchors_ = true
+
+[node name="Label2" type="Label" parent="."]
+offset_top = -80.0
+offset_right = 156.0
+offset_bottom = -57.0
+text = "Fast"
+metadata/_edit_use_anchors_ = true
+
+[node name="Label3" type="Label" parent="."]
+offset_left = 340.0
+offset_top = -80.0
+offset_right = 495.0
+offset_bottom = -57.0
+text = "Fast Hollow"
+metadata/_edit_use_anchors_ = true
+
+[node name="Label4" type="Label" parent="."]
+offset_left = 670.0
+offset_top = -80.0
+offset_right = 825.0
+offset_bottom = -57.0
+text = "Legacy"
+metadata/_edit_use_anchors_ = true
+
+[node name="Label5" type="Label" parent="."]
+offset_left = -200.0
+offset_top = 10.0
+offset_right = 36.0
+offset_bottom = 59.0
+text = "Closed Shape"
+metadata/_edit_use_anchors_ = true
+
+[node name="Label6" type="Label" parent="."]
+offset_left = -200.0
+offset_top = 260.0
+offset_right = 36.0
+offset_bottom = 309.0
+text = "Open Shape"
+metadata/_edit_use_anchors_ = true
+
+[node name="Label7" type="Label" parent="."]
+offset_left = 220.0
+offset_top = 390.0
+offset_right = 587.0
+offset_bottom = 439.0
+text = "(Hollow for open shapes is the same as Default)"
+metadata/_edit_use_anchors_ = true
+
+[node name="closed" type="Node2D" parent="."]
+position = Vector2(0, -30)
+
+[node name="closed_default" type="Node2D" parent="closed"]
+position = Vector2(-10, 10)
+script = ExtResource("1_bgypd")
+_points = SubResource("Resource_isa7x")
+_meshes = Array[ExtResource("5_b3my5")]([SubResource("Resource_q32v1")])
+shape_material = SubResource("Resource_ym61l")
+collision_size = 10.0
+collision_offset = 20.0
+collision_polygon_node_path = NodePath("CollisionPolygon2D")
+metadata/_custom_type_script = "uid://dhdc4b8yddyej"
+metadata/_edit_group_ = true
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="closed/closed_default"]
+polygon = PackedVector2Array(230, 37.1217, 230, 62.8783, 109.313, 117.736, 50, 153.324, -38.2929, 100.348, 42.2641, 50, -23.3796, 8.9727, -15.0703, -20, 104.332, -20)
+
+[node name="closed_hollow" type="Node2D" parent="closed"]
+position = Vector2(300, 20)
+script = ExtResource("1_bgypd")
+_points = SubResource("Resource_isa7x")
+_meshes = Array[ExtResource("5_b3my5")]([SubResource("Resource_ouyma")])
+shape_material = SubResource("Resource_ym61l")
+collision_generation_method = 2
+collision_size = 10.0
+collision_offset = 20.0
+collision_polygon_node_path = NodePath("CollisionPolygon2D")
+metadata/_custom_type_script = "uid://dhdc4b8yddyej"
+metadata/_edit_group_ = true
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="closed/closed_hollow"]
+polygon = PackedVector2Array(105.415, -25, -18.8379, -25, -29.2245, 11.2159, 32.8301, 50, -47.8661, 100.435, 50, 159.155, 111.641, 122.17, 235, 66.0978, 235, 33.9022, 105.415, -25, 103.249, -15, 225, 40.3413, 225, 59.6587, 106.985, 113.302, 50, 147.493, -28.7197, 100.261, 51.6981, 50, -17.5347, 6.72952, -11.3028, -15, 103.249, -15)
+
+[node name="closed_legacy" type="Node2D" parent="closed"]
+position = Vector2(620, 20)
+script = ExtResource("1_bgypd")
+_points = SubResource("Resource_isa7x")
+_meshes = Array[ExtResource("5_b3my5")]([SubResource("Resource_gmc7f")])
+shape_material = SubResource("Resource_ym61l")
+collision_generation_method = 1
+collision_size = 10.0
+collision_offset = 20.0
+collision_polygon_node_path = NodePath("CollisionPolygon2D")
+metadata/_custom_type_script = "uid://dhdc4b8yddyej"
+metadata/_edit_group_ = true
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="closed/closed_legacy"]
+polygon = PackedVector2Array(50, 138.646, -5.46133, 100.05, 74.465, 50, -2.99812, -0.85985, 102.071, -9.56291, 214.431, 50, 104.642, 108.84)
+
+[node name="open" type="Node2D" parent="."]
+position = Vector2(0, -30)
+
+[node name="open_default" type="Node2D" parent="open"]
+position = Vector2(-10, 260)
+script = ExtResource("1_bgypd")
+_points = SubResource("Resource_hff64")
+_meshes = Array[ExtResource("5_b3my5")]([SubResource("Resource_rilut")])
+shape_material = SubResource("Resource_6qbm5")
+collision_size = 10.0
+collision_offset = 20.0
+collision_polygon_node_path = NodePath("CollisionPolygon2D")
+metadata/_custom_type_script = "uid://dhdc4b8yddyej"
+metadata/_edit_group_ = true
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="open/open_default"]
+polygon = PackedVector2Array(229.413, 36.8549, 230.544, 61.2954, 149.923, 107.365, 144.961, 98.6824, 220.272, 55.6477, 219.706, 43.4274, 102.166, -10, -7.53518, -10, -11.6898, 4.48634, 61.132, 50, -19.1464, 100.174, 50, 141.662, 105.145, 108.575, 110.29, 117.15, 50, 153.324, -38.2929, 100.348, 42.2641, 50, -23.3796, 8.9727, -15.0703, -20, 104.332, -20)
+
+[node name="open_hollow" type="Node2D" parent="open"]
+position = Vector2(310, 260)
+script = ExtResource("1_bgypd")
+_points = SubResource("Resource_hff64")
+_meshes = Array[ExtResource("5_b3my5")]([SubResource("Resource_fy8q1")])
+shape_material = SubResource("Resource_6qbm5")
+collision_generation_method = 2
+collision_size = 10.0
+collision_offset = 20.0
+collision_polygon_node_path = NodePath("CollisionPolygon2D")
+metadata/_custom_type_script = "uid://dhdc4b8yddyej"
+metadata/_edit_group_ = true
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="open/open_hollow"]
+polygon = PackedVector2Array(229.413, 36.8549, 230.544, 61.2954, 149.923, 107.365, 144.961, 98.6824, 220.272, 55.6477, 219.706, 43.4274, 102.166, -10, -7.53518, -10, -11.6898, 4.48634, 61.132, 50, -19.1464, 100.174, 50, 141.662, 105.145, 108.575, 110.29, 117.15, 50, 153.324, -38.2929, 100.348, 42.2641, 50, -23.3796, 8.9727, -15.0703, -20, 104.332, -20)
+
+[node name="open_legacy" type="Node2D" parent="open"]
+position = Vector2(640, 260)
+script = ExtResource("1_bgypd")
+_points = SubResource("Resource_hff64")
+_meshes = Array[ExtResource("5_b3my5")]([SubResource("Resource_tax1t")])
+shape_material = SubResource("Resource_6qbm5")
+collision_generation_method = 1
+collision_size = 10.0
+collision_offset = 20.0
+collision_polygon_node_path = NodePath("CollisionPolygon2D")
+metadata/_custom_type_script = "uid://dhdc4b8yddyej"
+metadata/_edit_group_ = true
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="open/open_legacy"]
+polygon = PackedVector2Array(151.45, 185.749, 50, 216.462, -54.6133, 100.496, 24.6501, 50, -29.9812, -8.5985, 120.714, -95.6291, 258.217, 47.7679, 189.614, 176.824, 184.652, 168.142, 248.228, 48.2304, 118.597, -85.8557, -20.3687, -5.84167, 34.6501, 50, -44.6137, 100.406, 50, 206.462, 146.305, 177.174)

--- a/tests/unit/test_collisions.gd
+++ b/tests/unit/test_collisions.gd
@@ -1,0 +1,235 @@
+extends GutTest
+
+# This unit test is semi-useful.
+# It is there and can ensure that collisions won't break, however the tests are difficult to
+# understand reproduce since there is non-trivial math and thus ugly numbers involved.
+# These numbers were generated and printed from the collisions.tscn example and should cover all
+# edge-cases, i.e. normal corners and sharp corners, both inside and outside.
+# To make it a little more understandable, the polygon points were snapped to a 10x10 grid and
+# translated to (0, 0).
+
+const TEST_POLYGON_CLOSED: PackedVector2Array = [
+	Vector2(0.0, 0.0),
+	Vector2(-50.0, -30.0),
+	Vector2(30.0, -80.0),
+	Vector2(-50.0, -130.0),
+	Vector2(50.0, -130.0),
+	Vector2(160.0, -80.0),
+	Vector2(50.0, -30.0),
+	Vector2(0.0, 0.0)
+]
+
+const TEST_POLYGON_OPEN: PackedVector2Array = [
+	Vector2(0.0, 0.0),
+	Vector2(-50.0, 30.0),
+	Vector2(-100.0, 0.0),
+	Vector2(-20.0, -50.0),
+	Vector2(-100.0, -100.0),
+	Vector2(0.0, -100.0),
+	Vector2(110.0, -50.0),
+	Vector2(40.0, -10.0)
+]
+
+
+# collisions.tscn - "closed_default"
+func test_generate_filled() -> void:
+	# Unchanged
+	assert_points_equal(setup_gen(0, 100).generate_filled(TEST_POLYGON_CLOSED), TEST_POLYGON_CLOSED)  # collision_size should be ignored here
+	# Inflate
+	assert_points_equal(setup_gen(20, 10).generate_filled(TEST_POLYGON_CLOSED), [
+		Vector2(180.0, -92.87827),
+		Vector2(180.0, -67.12173),
+		Vector2(59.31312, -12.26407),
+		Vector2(0.0, 23.32381),
+		Vector2(-88.29287, -29.65191),
+		Vector2(-7.735939, -80.0),
+		Vector2(-73.37961, -121.0273),
+		Vector2(-65.07034, -150.0),
+		Vector2(54.33218, -150.0)
+	])
+
+	# Deflate
+	assert_points_equal(setup_gen(-20, 10).generate_filled(TEST_POLYGON_CLOSED), [
+		Vector2(45.66781, -110.0),
+		Vector2(111.6678, -80.00002),
+		Vector2(40.6869, -47.73595),
+		Vector2(0.0, -23.32382),
+		Vector2(-11.70713, -30.34809),
+		Vector2(67.73592, -80.0),
+		Vector2(19.73593, -110.0)
+	])
+
+
+# collisions.tscn - "open_default"
+func test_generate_open() -> void:
+	# Unchanged
+	assert_points_equal(setup_gen(0, 0).generate_open(TEST_POLYGON_OPEN), TEST_POLYGON_OPEN)
+	# Inflate
+	assert_points_equal(setup_gen(20, 10).generate_open(TEST_POLYGON_OPEN), [
+		Vector2(129.4129, -63.14512),
+		Vector2(130.5443, -38.70459),
+		Vector2(49.92278, 7.364868),
+		Vector2(44.96138, -1.317574),
+		Vector2(120.2721, -44.35232),
+		Vector2(119.7065, -56.57257),
+		Vector2(2.1661, -110.0),
+		Vector2(-107.5352, -110.0),
+		Vector2(-111.6898, -95.51366),
+		Vector2(-38.86796, -50.0),
+		Vector2(-119.1464, 0.174042),
+		Vector2(-50.0, 41.66191),
+		Vector2(5.144958, 8.574944),
+		Vector2(10.28992, 17.14986),
+		Vector2(-50.0, 53.32381),
+		Vector2(-138.2929, 0.348091),
+		Vector2(-57.73592, -50.00001),
+		Vector2(-123.3796, -91.0273),
+		Vector2(-115.0704, -120.0),
+		Vector2(4.332191, -120.0)])
+
+	# Deflate
+	assert_points_equal(setup_gen(-10, 10).generate_open(TEST_POLYGON_OPEN), [
+		Vector2(81.95457, -51.76333),
+		Vector2(82.23744, -45.6532),
+		Vector2(35.03862, -18.68243),
+		Vector2(30.07722, -27.36487),
+		Vector2(66.13515, -47.96941),
+		Vector2(-4.332176, -80.0),
+		Vector2(-30.26408, -80.0),
+		Vector2(17.73592, -50.0),
+		Vector2(-61.70715, -0.348099),
+		Vector2(-50.00001, 6.676193),
+		Vector2(-10.28992, -17.14986),
+		Vector2(-5.144958, -8.574944),
+		Vector2(-50.0, 18.33809),
+		Vector2(-80.85357, -0.174049),
+		Vector2(-1.132042, -50.0),
+		Vector2(-53.54295, -82.75681),
+		Vector2(-51.46564, -89.99999),
+		Vector2(-2.166092, -90.0)
+	])
+
+
+# collisions.tscn - "closed_hollow"
+func test_generate_hollow() -> void:
+	# Inflate
+	assert_points_equal(setup_gen(20, 10).generate_hollow(TEST_POLYGON_CLOSED), [
+		Vector2(55.41523, -155.0),
+		Vector2(-68.83793, -155.0),
+		Vector2(-79.22451, -118.7841),
+		Vector2(-17.16991, -80.00002),
+		Vector2(-97.86608, -29.56489),
+		Vector2(0.0, 29.15475),
+		Vector2(61.64136, -7.83007),
+		Vector2(185.0, -63.90217),
+		Vector2(185.0, -96.09783),
+		Vector2(55.41523, -155.0),
+		Vector2(53.24914, -145.0),
+		Vector2(175.0, -89.6587),
+		Vector2(175.0, -70.3413),
+		Vector2(56.9848, -16.69804),
+		Vector2(0.0, 17.49286),
+		Vector2(-78.71965, -29.73893),
+		Vector2(1.698059, -80.00002),
+		Vector2(-67.5347, -123.2705),
+		Vector2(-61.30276, -145.0),
+		Vector2(53.24914, -145.0)
+	])
+
+	# Deflate
+	assert_points_equal(setup_gen(-20, 10).generate_hollow(TEST_POLYGON_CLOSED), [
+		Vector2(2.301941, -115.0),
+		Vector2(58.30194, -80.0),
+		Vector2(-21.28036, -30.26107),
+		Vector2(0.0, -17.49286),
+		Vector2(43.01517, -43.30196),
+		Vector2(123.7509, -80.00002),
+		Vector2(46.75086, -115.0),
+		Vector2(2.301941, -115.0),
+		Vector2(37.16991, -105.0),
+		Vector2(44.58478, -105.0),
+		Vector2(99.58476, -80.00002),
+		Vector2(38.35862, -52.16993),
+		Vector2(0.0, -29.15476),
+		Vector2(-2.13393, -30.43511),
+		Vector2(77.16991, -80.0),
+		Vector2(37.16991, -105.0)])
+
+
+
+func test_simple_offset_open_polygon_miter() -> void:
+	# Unchanged
+	assert_eq(SS2D_CollisionGen.simple_offset_open_polygon_miter(TEST_POLYGON_OPEN, 0).size(), 0)
+	# Inflate
+	assert_points_equal(SS2D_CollisionGen.simple_offset_open_polygon_miter(TEST_POLYGON_OPEN, 20), [
+		Vector2(10.28992, 17.14986),
+		Vector2(-50.0, 53.32381),
+		Vector2(-138.2929, 0.348091),
+		Vector2(-57.73592, -50.0),
+		Vector2(-123.3796, -91.02731),
+		Vector2(-115.0703, -120.0),
+		Vector2(4.332184, -120.0),
+		Vector2(129.4129, -63.14513),
+		Vector2(130.5443, -38.70458),
+		Vector2(49.92278, 7.364861)
+	])
+
+	# Deflate
+	assert_points_equal(SS2D_CollisionGen.simple_offset_open_polygon_miter(TEST_POLYGON_OPEN, -10), [
+		Vector2(-5.144958, -8.574928),
+		Vector2(-50.0, 18.3381),
+		Vector2(-80.85356, -0.174042),
+		Vector2(-1.132034, -50.0),
+		Vector2(-65.13203, -89.99999),
+		Vector2(-2.166092, -90.0),
+		Vector2(88.06758, -48.9847),
+		Vector2(35.0386, -18.68243)
+	])
+
+
+func test_insufficient_points() -> void:
+	var points0 := PackedVector2Array()
+	var points1 := PackedVector2Array([Vector2(0, 0)])
+	var points2 := PackedVector2Array([Vector2(0, 0), Vector2(1, 1)])
+	var gen := setup_gen(100, 100)
+
+	for i: PackedVector2Array in [ points0, points1, points2 ]:
+		assert_eq(gen.generate_hollow(i).size(), 0)
+		assert_eq(gen.generate_filled(i).size(), 0)
+
+	assert_eq(gen.generate_open(points0).size(), 0)
+	assert_eq(gen.generate_open(points1).size(), 0)
+	assert_eq(SS2D_CollisionGen.simple_offset_open_polygon_miter(points0, 100).size(), 0)
+	assert_eq(SS2D_CollisionGen.simple_offset_open_polygon_miter(points1, 100).size(), 0)
+
+
+static func setup_gen(offset: float, size: float) -> SS2D_CollisionGen:
+	var gen := SS2D_CollisionGen.new()
+	gen.collision_offset = offset
+	gen.collision_size = size
+	return gen
+
+
+func assert_points_equal(points: PackedVector2Array, expected: PackedVector2Array) -> void:
+	assert_eq(points.size(),  expected.size())
+
+	points = reorder_points(points, expected[0])
+
+	for i in mini(points.size(), expected.size()):
+		assert_true(points[i].is_equal_approx(expected[i]), "Point mismatch at index %d: %s != %s" % [i, points[i], expected[i]])
+
+
+## Geometry2D.offset_polygon/polyline() may reorder points so re-reorder them to a known start point.
+func reorder_points(points: PackedVector2Array, known_start_point: Vector2) -> PackedVector2Array:
+	for i in points.size():
+		if points[i].is_equal_approx(known_start_point):
+			if i == 0:
+				return points
+
+			# reorder points so that the known start point is at the beginning
+			var reordered := points.slice(i)
+			reordered.append_array(points.slice(0, i))
+			return reordered
+
+	fail_test("Known point not found")
+	return points

--- a/tests/unit/test_collisions.gd.uid
+++ b/tests/unit/test_collisions.gd.uid
@@ -1,0 +1,1 @@
+uid://cf0eiak0xyinq


### PR DESCRIPTION
This started out with a small idea to use `Geometry2D.offset_polyline()` to generate collisions for open shapes.
But then edge cases and the feature creep appeared and it grew into something much larger :D 

This PR improves collision generation and makes the old mesh based approach pretty much obsolete.
It adds faster collision generation for open shapes and introduces hollow collision generation for closed shapes, which solves #110.
`collision_offset` and `collision_size` will now be correctly applied as well.
The performance improvement is around 6x faster (0.05ms vs 0.3 ms on a rather simple test scene) than the old mesh based approach.
I also added a `collisions.tscn` example that demonstrates the different collision methods on closed and open shapes.

I also reworked the Collision Tool to be more useful.
It now only creates a `CollisionPolygon2D`. There is also a new setting to specify under which node the polygon should be added. This allows having a single `StaticBody2D` for example and automatically adding all new collisions there.
Below is a sloppy demo video.

~~Finally, I noticed that the recent baked-shapes update introduced VCS noise by frequently creating new resource instances which causes new IDs to be assigned and thus changes to the scene file even though the content itself did not change.
I fixed this by reusing existing `SS2D_Mesh` instances and getting rid of `SS2D_VertexProperties`.~~
Moved into separate PR. 

Details to all changes are in the commit messages as usual.

After this gets merged, I'm going to create a new release.

---

Collision Tool demo

https://github.com/user-attachments/assets/75be12a3-9e68-4aff-a582-c67e776e9449

